### PR TITLE
chore: Enable Google provider version 5 (remove max version constraint)

### DIFF
--- a/modules/autoscale/README.md
+++ b/modules/autoscale/README.md
@@ -7,14 +7,14 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 2.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 5.12 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.54 |
 
 ### Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | n/a |
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 5.12 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 4.54 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ### Modules

--- a/modules/autoscale/README.md
+++ b/modules/autoscale/README.md
@@ -7,14 +7,14 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 2.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.54 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 5.0.0 |
 
 ### Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | n/a |
-| <a name="provider_google"></a> [google](#provider\_google) | >= 4.54 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 5.0.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ### Modules

--- a/modules/autoscale/README.md
+++ b/modules/autoscale/README.md
@@ -7,14 +7,14 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 2.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 4.54 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 5.12 |
 
 ### Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | n/a |
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 4.54 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 5.12 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ### Modules

--- a/modules/autoscale/README.md
+++ b/modules/autoscale/README.md
@@ -7,14 +7,14 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 2.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 5.0.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 5 |
 
 ### Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | n/a |
-| <a name="provider_google"></a> [google](#provider\_google) | >= 5.0.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 5 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ### Modules

--- a/modules/autoscale/main.tf
+++ b/modules/autoscale/main.tf
@@ -241,7 +241,7 @@ resource "google_secret_manager_secret" "delicensing_cfn_pano_creds" {
   project   = var.project_id
   secret_id = local.delicensing_cfn.secret_name
   replication {
-    automatic = true
+    auto {}
   }
 }
 

--- a/modules/autoscale/versions.tf
+++ b/modules/autoscale/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.3, < 2.0"
   required_providers {
     google = {
-      version = "~> 5.12"
+      version = ">= 4.54"
     }
   }
 }

--- a/modules/autoscale/versions.tf
+++ b/modules/autoscale/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.3, < 2.0"
   required_providers {
     google = {
-      version = ">= 4.54"
+      version = ">= 5.0.0"
     }
   }
 }

--- a/modules/autoscale/versions.tf
+++ b/modules/autoscale/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.3, < 2.0"
   required_providers {
     google = {
-      version = ">= 5.0.0"
+      version = ">= 5"
     }
   }
 }

--- a/modules/autoscale/versions.tf
+++ b/modules/autoscale/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.3, < 2.0"
   required_providers {
     google = {
-      version = "~> 4.54"
+      version = "~> 5.12"
     }
   }
 }

--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -7,13 +7,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 2.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 4.54 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 5.12 |
 
 ### Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 4.54 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 5.12 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ### Modules

--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -7,13 +7,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 2.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 5.12 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.54 |
 
 ### Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 5.12 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 4.54 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ### Modules

--- a/modules/bootstrap/versions.tf
+++ b/modules/bootstrap/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = ">= 1.3, < 2.0"
   required_providers {
-    google = { version = "~> 5.12" }
+    google = { version = ">= 4.54" }
   }
 }

--- a/modules/bootstrap/versions.tf
+++ b/modules/bootstrap/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = ">= 1.3, < 2.0"
   required_providers {
-    google = { version = "~> 4.54" }
+    google = { version = "~> 5.12" }
   }
 }

--- a/modules/iam_service_account/README.md
+++ b/modules/iam_service_account/README.md
@@ -14,13 +14,13 @@ The account produced by this module is intended to have minimal required permiss
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 2.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 5.12 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.54 |
 
 ### Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 5.12 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 4.54 |
 
 ### Modules
 

--- a/modules/iam_service_account/README.md
+++ b/modules/iam_service_account/README.md
@@ -14,13 +14,13 @@ The account produced by this module is intended to have minimal required permiss
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 2.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 4.54 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 5.12 |
 
 ### Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 4.54 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 5.12 |
 
 ### Modules
 

--- a/modules/iam_service_account/versions.tf
+++ b/modules/iam_service_account/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = ">= 1.3, < 2.0"
   required_providers {
-    google = { version = "~> 5.12" }
+    google = { version = ">= 4.54" }
   }
 }

--- a/modules/iam_service_account/versions.tf
+++ b/modules/iam_service_account/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = ">= 1.3, < 2.0"
   required_providers {
-    google = { version = "~> 4.54" }
+    google = { version = "~> 5.12" }
   }
 }

--- a/modules/lb_external/README.md
+++ b/modules/lb_external/README.md
@@ -15,13 +15,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 2.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 4.54 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 5.12 |
 
 ### Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 4.54 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 5.12 |
 | <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | n/a |
 
 ### Modules

--- a/modules/lb_external/README.md
+++ b/modules/lb_external/README.md
@@ -15,13 +15,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 2.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 5.12 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.54 |
 
 ### Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 5.12 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 4.54 |
 | <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | n/a |
 
 ### Modules

--- a/modules/lb_external/versions.tf
+++ b/modules/lb_external/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = ">= 1.3, < 2.0"
   required_providers {
-    google = { version = "~> 5.12" }
+    google = { version = ">= 4.54" }
   }
 }

--- a/modules/lb_external/versions.tf
+++ b/modules/lb_external/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = ">= 1.3, < 2.0"
   required_providers {
-    google = { version = "~> 4.54" }
+    google = { version = "~> 5.12" }
   }
 }

--- a/modules/lb_http_ext_global/README.md
+++ b/modules/lb_http_ext_global/README.md
@@ -38,13 +38,13 @@ Thus if you re-use the same IG for this module (HTTP LB) you need balancing_mode
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 2.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 4.54 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 5.12 |
 
 ### Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 4.54 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 5.12 |
 
 ### Modules
 

--- a/modules/lb_http_ext_global/README.md
+++ b/modules/lb_http_ext_global/README.md
@@ -38,13 +38,13 @@ Thus if you re-use the same IG for this module (HTTP LB) you need balancing_mode
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 2.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 5.12 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.54 |
 
 ### Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 5.12 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 4.54 |
 
 ### Modules
 

--- a/modules/lb_http_ext_global/versions.tf
+++ b/modules/lb_http_ext_global/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = ">= 1.3, < 2.0"
   required_providers {
-    google = { version = "~> 5.12" }
+    google = { version = ">= 4.54" }
   }
 }

--- a/modules/lb_http_ext_global/versions.tf
+++ b/modules/lb_http_ext_global/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = ">= 1.3, < 2.0"
   required_providers {
-    google = { version = "~> 4.54" }
+    google = { version = "~> 5.12" }
   }
 }

--- a/modules/lb_internal/README.md
+++ b/modules/lb_internal/README.md
@@ -7,13 +7,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 2.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 5.12 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.54 |
 
 ### Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 5.12 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 4.54 |
 | <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | n/a |
 
 ### Modules

--- a/modules/lb_internal/README.md
+++ b/modules/lb_internal/README.md
@@ -7,13 +7,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 2.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 4.54 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 5.12 |
 
 ### Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 4.54 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 5.12 |
 | <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | n/a |
 
 ### Modules

--- a/modules/lb_internal/versions.tf
+++ b/modules/lb_internal/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = ">= 1.3, < 2.0"
   required_providers {
-    google = { version = "~> 5.12" }
+    google = { version = ">= 4.54" }
   }
 }

--- a/modules/lb_internal/versions.tf
+++ b/modules/lb_internal/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = ">= 1.3, < 2.0"
   required_providers {
-    google = { version = "~> 4.54" }
+    google = { version = "~> 5.12" }
   }
 }

--- a/modules/panorama/README.md
+++ b/modules/panorama/README.md
@@ -13,13 +13,13 @@ For usage, check the "examples" folder in the root of the repository.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 2.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 4.54 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 5.12 |
 
 ### Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 4.54 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 5.12 |
 
 ### Modules
 

--- a/modules/panorama/README.md
+++ b/modules/panorama/README.md
@@ -13,13 +13,13 @@ For usage, check the "examples" folder in the root of the repository.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 2.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 5.12 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.54 |
 
 ### Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 5.12 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 4.54 |
 
 ### Modules
 

--- a/modules/panorama/versions.tf
+++ b/modules/panorama/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.3, < 2.0"
   required_providers {
     google = {
-      version = "~> 5.12"
+      version = ">= 4.54"
     }
   }
 }

--- a/modules/panorama/versions.tf
+++ b/modules/panorama/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.3, < 2.0"
   required_providers {
     google = {
-      version = "~> 4.54"
+      version = "~> 5.12"
     }
   }
 }

--- a/modules/vmseries/README.md
+++ b/modules/vmseries/README.md
@@ -13,14 +13,14 @@ When troubleshooting you can use this module also with a good ol' Linux image. I
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 2.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 4.54 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 5.12 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1 |
 
 ### Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 4.54 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 5.12 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1 |
 
 ### Modules

--- a/modules/vmseries/README.md
+++ b/modules/vmseries/README.md
@@ -13,14 +13,14 @@ When troubleshooting you can use this module also with a good ol' Linux image. I
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 2.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 5.12 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.54 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1 |
 
 ### Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 5.12 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 4.54 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1 |
 
 ### Modules

--- a/modules/vmseries/versions.tf
+++ b/modules/vmseries/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 1.3, < 2.0"
   required_providers {
     null   = { version = "~> 3.1" }
-    google = { version = "~> 4.54" }
+    google = { version = "~> 5.12" }
   }
 }

--- a/modules/vmseries/versions.tf
+++ b/modules/vmseries/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 1.3, < 2.0"
   required_providers {
     null   = { version = "~> 3.1" }
-    google = { version = "~> 5.12" }
+    google = { version = ">= 4.54" }
   }
 }

--- a/modules/vpc-peering/README.md
+++ b/modules/vpc-peering/README.md
@@ -11,12 +11,13 @@ By default, no routes are exported/imported for each direction, every option has
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 2.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.54 |
 
 ### Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | n/a |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 4.54 |
 
 ### Modules
 

--- a/modules/vpc-peering/versions.tf
+++ b/modules/vpc-peering/versions.tf
@@ -1,3 +1,8 @@
 terraform {
   required_version = ">= 1.3, < 2.0"
+  required_providers {
+    google = {
+      version = ">= 4.54"
+    }
+  }
 }

--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -11,13 +11,13 @@ One advantage of this module over the [terraform-google-network](https://github.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 2.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 4.54 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 5.12 |
 
 ### Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 4.54 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 5.12 |
 
 ### Modules
 

--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -11,13 +11,13 @@ One advantage of this module over the [terraform-google-network](https://github.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 2.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 5.12 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.54 |
 
 ### Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 5.12 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 4.54 |
 
 ### Modules
 

--- a/modules/vpc/versions.tf
+++ b/modules/vpc/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.3, < 2.0"
   required_providers {
     google = {
-      version = "~> 5.12"
+      version = ">= 4.54"
     }
   }
 }

--- a/modules/vpc/versions.tf
+++ b/modules/vpc/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.3, < 2.0"
   required_providers {
     google = {
-      version = "~> 4.54"
+      version = "~> 5.12"
     }
   }
 }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
This update includes bumping the Terraform version to 5.12. The primary goal of this change is to ensure compatibility with the latest google api  features and improvements, as well as to maintain up-to-date practices within our infrastructure management.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Major version API upgrades are essential for leveraging the latest functionalities and enhancements offered by the Google provider. This change is driven by the need to stay aligned with the evolving landscape of infrastructure as code (IaC) and to utilize the improved performance and features of the latest google version.

<!--- If it fixes an open issue, please link to the issue here. -->
#6 
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Followed the contributor's guideline and ran `pre-commit run -a` to ensure the unit tests were passing 

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
