### PR TITLE
fix(modules/panorama): Use of an already reserved external IP

### DIFF
--- a/modules/panorama/main.tf
+++ b/modules/panorama/main.tf
@@ -17,7 +17,7 @@ resource "google_compute_address" "private" {
 
 # Permanent public address, not ephemeral.
 resource "google_compute_address" "public" {
-  count = var.attach_public_ip ? 1 : 0
+  count = var.attach_public_ip && var.reserve_public_ip ? 1 : 0
 
   name    = "${var.name}-public"
   project = var.project
@@ -62,7 +62,7 @@ resource "google_compute_instance" "this" {
     dynamic "access_config" {
       for_each = var.attach_public_ip ? [""] : []
       content {
-        nat_ip = google_compute_address.public[0].address
+        nat_ip = var.reserve_public_ip ? google_compute_address.public[0].address : var.public_static_ip
       }
     }
 

--- a/modules/panorama/main.tf
+++ b/modules/panorama/main.tf
@@ -62,7 +62,7 @@ resource "google_compute_instance" "this" {
     dynamic "access_config" {
       for_each = var.attach_public_ip ? [""] : []
       content {
-        nat_ip = var.reserve_public_ip ? google_compute_address.public[0].address : var.public_static_ip
+        nat_ip = try(var.public_static_ip, google_compute_address.public[0].address)
       }
     }
 

--- a/modules/panorama/main.tf
+++ b/modules/panorama/main.tf
@@ -17,7 +17,7 @@ resource "google_compute_address" "private" {
 
 # Permanent public address, not ephemeral.
 resource "google_compute_address" "public" {
-  count = var.attach_public_ip && var.reserve_public_ip ? 1 : 0
+  count = var.attach_public_ip && var.public_static_ip == null ? 1 : 0
 
   name    = "${var.name}-public"
   project = var.project

--- a/modules/panorama/variables.tf
+++ b/modules/panorama/variables.tf
@@ -46,10 +46,6 @@ variable "public_static_ip" {
   default     = null
 }
 
-variable "reserve_public_ip" {
-  description = "Determines if a Public IP needs to be reserved or not. Set this to false, if you have already reserved public ip outside of this module"
-  type        = bool
-  default     = true
 }
 
 variable "log_disks" {

--- a/modules/panorama/variables.tf
+++ b/modules/panorama/variables.tf
@@ -46,8 +46,6 @@ variable "public_static_ip" {
   default     = null
 }
 
-}
-
 variable "log_disks" {
   description = <<-EOF
   List of disks to create and attach to Panorama to store traffic logs.

--- a/modules/panorama/variables.tf
+++ b/modules/panorama/variables.tf
@@ -46,6 +46,12 @@ variable "public_static_ip" {
   default     = null
 }
 
+variable "reserve_public_ip" {
+  description = "Determines if a Public IP needs to be reserved or not. Set this to false, if you have already reserved public ip outside of this module"
+  type        = bool
+  default     = true
+}
+
 variable "log_disks" {
   description = <<-EOF
   List of disks to create and attach to Panorama to store traffic logs.


### PR DESCRIPTION
The following changes allows assigning a already reserved public IP address to the panorama machines. 

1. Added a new variable "reserve_public_ip". If set to true , public_static_ip mentioned will be reserved by the panorama module. If set to false, it will not reserve the ip rather it would directly add "public_static_ip" to the network interface. 

Fixes #12 