### PR TITLE
fix(modules/autoscale): google_secret_manager_secret argument deprecation warning

### DIFF
--- a/modules/autoscale/main.tf
+++ b/modules/autoscale/main.tf
@@ -241,7 +241,7 @@ resource "google_secret_manager_secret" "delicensing_cfn_pano_creds" {
   project   = var.project_id
   secret_id = local.delicensing_cfn.secret_name
   replication {
-    automatic = true
+    auto {}
   }
 }
 


### PR DESCRIPTION
## Description

Update `google_secret_manager_secret` argument to use current spec.

## Motivation and Context

Resolves #14 

## How Has This Been Tested?

Apply `vpc_peering_common_with_autoscale` example, modified to include delicensing feature.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
