### PR TITLE
feat(modules/lb_http_ext_global): Adding IPv6 support to the `lb_http_ext_global` module

### DIFF
--- a/modules/lb_http_ext_global/README.md
+++ b/modules/lb_http_ext_global/README.md
@@ -8,10 +8,18 @@ participating groups are equally capable as well.
 ```terraform
 
 module "glb" {
-  source = "../modules/lb_http_ext_global"
-  name   = "my-glb"
+  source                = "../modules/lb_http_ext_global"
+  name                  = "my-glb"
   backend_groups        = module.vmseries.instance_group_self_links
   max_rate_per_instance = 50000
+}
+
+module "glb_dual_stack" {
+  source                = "../modules/lb_http_ext_global"
+  name                  = "my-glb-dual-stack"
+  backend_groups        = module.vmseries.instance_group_self_links
+  max_rate_per_instance = 50000
+  ip_version            = "IPV4_IPV6"
 }
 
 ```
@@ -56,8 +64,11 @@ No modules.
 |------|------|
 | [google_compute_backend_service.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_backend_service) | resource |
 | [google_compute_global_address.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
+| [google_compute_global_address.default_v6](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
 | [google_compute_global_forwarding_rule.http](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_forwarding_rule) | resource |
+| [google_compute_global_forwarding_rule.http_v6](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_forwarding_rule) | resource |
 | [google_compute_global_forwarding_rule.https](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_forwarding_rule) | resource |
+| [google_compute_global_forwarding_rule.https_v6](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_forwarding_rule) | resource |
 | [google_compute_health_check.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_health_check) | resource |
 | [google_compute_ssl_certificate.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_ssl_certificate) | resource |
 | [google_compute_target_http_proxy.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_target_http_proxy) | resource |
@@ -79,7 +90,7 @@ No modules.
 | <a name="input_health_check_name"></a> [health\_check\_name](#input\_health\_check\_name) | Name for the health check. If not provided, defaults to `<var.name>-healthcheck`. | `string` | `null` | no |
 | <a name="input_health_check_port"></a> [health\_check\_port](#input\_health\_check\_port) | TCP port to use for health check. | `number` | `80` | no |
 | <a name="input_http_forward"></a> [http\_forward](#input\_http\_forward) | Set to `false` to disable HTTP port 80 forward | `bool` | `true` | no |
-| <a name="input_ip_version"></a> [ip\_version](#input\_ip\_version) | IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4 | `string` | `""` | no |
+| <a name="input_ip_version"></a> [ip\_version](#input\_ip\_version) | IP version for the Global address: IPV4, IPV6 or IPV4\_IPV6. Empty defaults to IPV4 | `string` | `""` | no |
 | <a name="input_max_connections_per_instance"></a> [max\_connections\_per\_instance](#input\_max\_connections\_per\_instance) | n/a | `number` | `null` | no |
 | <a name="input_max_rate_per_instance"></a> [max\_rate\_per\_instance](#input\_max\_rate\_per\_instance) | n/a | `number` | `null` | no |
 | <a name="input_max_utilization"></a> [max\_utilization](#input\_max\_utilization) | n/a | `number` | `null` | no |
@@ -97,5 +108,6 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_address"></a> [address](#output\_address) | n/a |
+| <a name="output_address_v6"></a> [address\_v6](#output\_address\_v6) | n/a |
 | <a name="output_all"></a> [all](#output\_all) | Intended mainly for `depends_on` but currently succeeds prematurely (while forwarding rules and healtchecks are not yet usable). |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/lb_http_ext_global/README.md
+++ b/modules/lb_http_ext_global/README.md
@@ -63,8 +63,8 @@ No modules.
 | Name | Type |
 |------|------|
 | [google_compute_backend_service.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_backend_service) | resource |
-| [google_compute_global_address.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
-| [google_compute_global_address.default_v6](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
+| [google_compute_global_address.ipv4](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
+| [google_compute_global_address.ipv6](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
 | [google_compute_global_forwarding_rule.http](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_forwarding_rule) | resource |
 | [google_compute_global_forwarding_rule.http_v6](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_forwarding_rule) | resource |
 | [google_compute_global_forwarding_rule.https](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_forwarding_rule) | resource |

--- a/modules/lb_http_ext_global/main.tf
+++ b/modules/lb_http_ext_global/main.tf
@@ -1,22 +1,59 @@
+locals {
+  ipv4       = contains(["", "IPV4", "IPV4_IPV6"], var.ip_version)
+  ipv4_http  = local.ipv4 && var.http_forward ? true : false
+  ipv4_https = local.ipv4 && var.ssl ? true : false
+  ipv6       = contains(["IPV6", "IPV4_IPV6"], var.ip_version)
+  ipv6_http  = local.ipv6 && var.http_forward ? true : false
+  ipv6_https = local.ipv6 && var.ssl ? true : false
+}
+
 resource "google_compute_global_forwarding_rule" "http" {
-  count      = var.http_forward ? 1 : 0
+  count      = local.ipv4_http ? 1 : 0
   name       = "${var.name}-http"
   target     = google_compute_target_http_proxy.default[0].self_link
-  ip_address = google_compute_global_address.default.address
+  ip_address = google_compute_global_address.default[0].address
+  port_range = "80"
+}
+
+resource "google_compute_global_forwarding_rule" "http_v6" {
+  count      = local.ipv6_http ? 1 : 0
+  name       = "${var.name}-http-v6"
+  target     = google_compute_target_http_proxy.default[0].self_link
+  ip_address = google_compute_global_address.default_v6[0].address
   port_range = "80"
 }
 
 resource "google_compute_global_forwarding_rule" "https" {
-  count      = var.ssl ? 1 : 0
+  count      = local.ipv4_https ? 1 : 0
   name       = "${var.name}-https"
   target     = google_compute_target_https_proxy.default[0].self_link
-  ip_address = google_compute_global_address.default.address
+  ip_address = google_compute_global_address.default[0].address
   port_range = "443"
 }
 
+resource "google_compute_global_forwarding_rule" "https_v6" {
+  count      = local.ipv6_https ? 1 : 0
+  name       = "${var.name}-https-v6"
+  target     = google_compute_target_https_proxy.default[0].self_link
+  ip_address = google_compute_global_address.default_v6[0].address
+  port_range = "443"
+}
+
+moved {
+  from = google_compute_global_address.default
+  to   = google_compute_global_address.default[0]
+}
+
 resource "google_compute_global_address" "default" {
+  count      = local.ipv4 ? 1 : 0
   name       = "${var.name}-address"
-  ip_version = var.ip_version
+  ip_version = "IPV4"
+}
+
+resource "google_compute_global_address" "default_v6" {
+  count      = local.ipv6 ? 1 : 0
+  name       = "${var.name}-address-v6"
+  ip_version = "IPV6"
 }
 
 # HTTP proxy when ssl is false

--- a/modules/lb_http_ext_global/main.tf
+++ b/modules/lb_http_ext_global/main.tf
@@ -44,7 +44,7 @@ moved {
   to   = google_compute_global_address.default[0]
 }
 
-resource "google_compute_global_address" "default" {
+resource "google_compute_global_address" "ipv4" {
   count      = local.ipv4 ? 1 : 0
   name       = "${var.name}-address"
   ip_version = "IPV4"

--- a/modules/lb_http_ext_global/main.tf
+++ b/modules/lb_http_ext_global/main.tf
@@ -50,7 +50,7 @@ resource "google_compute_global_address" "default" {
   ip_version = "IPV4"
 }
 
-resource "google_compute_global_address" "default_v6" {
+resource "google_compute_global_address" "ipv6" {
   count      = local.ipv6 ? 1 : 0
   name       = "${var.name}-address-v6"
   ip_version = "IPV6"

--- a/modules/lb_http_ext_global/main.tf
+++ b/modules/lb_http_ext_global/main.tf
@@ -11,7 +11,7 @@ resource "google_compute_global_forwarding_rule" "http" {
   count      = local.ipv4_http ? 1 : 0
   name       = "${var.name}-http"
   target     = google_compute_target_http_proxy.default[0].self_link
-  ip_address = google_compute_global_address.default[0].address
+  ip_address = google_compute_global_address.ipv4[0].address
   port_range = "80"
 }
 
@@ -19,7 +19,7 @@ resource "google_compute_global_forwarding_rule" "http_v6" {
   count      = local.ipv6_http ? 1 : 0
   name       = "${var.name}-http-v6"
   target     = google_compute_target_http_proxy.default[0].self_link
-  ip_address = google_compute_global_address.default_v6[0].address
+  ip_address = google_compute_global_address.ipv6[0].address
   port_range = "80"
 }
 
@@ -27,7 +27,7 @@ resource "google_compute_global_forwarding_rule" "https" {
   count      = local.ipv4_https ? 1 : 0
   name       = "${var.name}-https"
   target     = google_compute_target_https_proxy.default[0].self_link
-  ip_address = google_compute_global_address.default[0].address
+  ip_address = google_compute_global_address.ipv4[0].address
   port_range = "443"
 }
 
@@ -35,13 +35,13 @@ resource "google_compute_global_forwarding_rule" "https_v6" {
   count      = local.ipv6_https ? 1 : 0
   name       = "${var.name}-https-v6"
   target     = google_compute_target_https_proxy.default[0].self_link
-  ip_address = google_compute_global_address.default_v6[0].address
+  ip_address = google_compute_global_address.ipv6[0].address
   port_range = "443"
 }
 
 moved {
   from = google_compute_global_address.default
-  to   = google_compute_global_address.default[0]
+  to   = google_compute_global_address.ipv4[0]
 }
 
 resource "google_compute_global_address" "ipv4" {

--- a/modules/lb_http_ext_global/outputs.tf
+++ b/modules/lb_http_ext_global/outputs.tf
@@ -1,9 +1,9 @@
 output "address" {
-  value = try(google_compute_global_address.default[0].address, null)
+  value = try(google_compute_global_address.ipv4[0].address, null)
 }
 
 output "address_v6" {
-  value = try(google_compute_global_address.default_v6[0].address, null)
+  value = try(google_compute_global_address.ipv6[0].address, null)
 }
 
 output "all" {

--- a/modules/lb_http_ext_global/outputs.tf
+++ b/modules/lb_http_ext_global/outputs.tf
@@ -1,12 +1,18 @@
 output "address" {
-  value = google_compute_global_address.default.address
+  value = try(google_compute_global_address.default[0].address, null)
+}
+
+output "address_v6" {
+  value = try(google_compute_global_address.default_v6[0].address, null)
 }
 
 output "all" {
   description = "Intended mainly for `depends_on` but currently succeeds prematurely (while forwarding rules and healtchecks are not yet usable)."
   value = {
-    google_compute_global_forwarding_rule_http  = google_compute_global_forwarding_rule.http
-    google_compute_global_forwarding_rule_https = google_compute_global_forwarding_rule.https
-    google_compute_health_check                 = google_compute_health_check.default
+    google_compute_global_forwarding_rule_http     = google_compute_global_forwarding_rule.http
+    google_compute_global_forwarding_rule_https    = google_compute_global_forwarding_rule.https
+    google_compute_global_forwarding_rule_http_v6  = google_compute_global_forwarding_rule.http_v6
+    google_compute_global_forwarding_rule_https_v6 = google_compute_global_forwarding_rule.https_v6
+    google_compute_health_check                    = google_compute_health_check.default
   }
 }

--- a/modules/lb_http_ext_global/variables.tf
+++ b/modules/lb_http_ext_global/variables.tf
@@ -1,7 +1,11 @@
 variable "ip_version" {
-  description = "IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4"
+  description = "IP version for the Global address: IPV4, IPV6 or IPV4_IPV6. Empty defaults to IPV4"
   type        = string
   default     = ""
+  validation {
+    condition     = contains(["", "IPV4", "IPV6", "IPV4_IPV6"], var.ip_version)
+    error_message = "ip_version value must be either '', 'IPV4', 'IPV6 'or 'IPV4_IPV6'."
+  }
 }
 
 variable "name" {


### PR DESCRIPTION
## Description

`lb_http_ext_global` module now supports:
- Using IPv6 public IP address for the frontend
- Using IPv4 and IPv6 public IP addresses (dual-stack setup) for the frontend

Even though the load balancer now supports IPv6 connectivity to the client, IPv4 only connectivity is supported towards the backend.

## Motivation and Context

Enabling networks that rely on IPv6 connectivity.

## How Has This Been Tested?

- Creating and deleting resources according to the example usage (see README).
- Setting the load balancer as part of the lab deployment.

## Screenshots (if appropriate)

N/A

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
