### PR TITLE
Adding IPv6 support to vpc-peering

### DIFF
--- a/modules/vpc-peering/README.md
+++ b/modules/vpc-peering/README.md
@@ -47,6 +47,7 @@ No modules.
 | <a name="input_peer_import_subnet_routes_with_public_ip"></a> [peer\_import\_subnet\_routes\_with\_public\_ip](#input\_peer\_import\_subnet\_routes\_with\_public\_ip) | Import subnet routes with public IP setting for 'peer->local' direction. | `bool` | `false` | no |
 | <a name="input_peer_network"></a> [peer\_network](#input\_peer\_network) | Self-link or id of the second network (peer) in pair. | `string` | n/a | yes |
 | <a name="input_peer_peering_name"></a> [peer\_peering\_name](#input\_peer\_peering\_name) | Name for 'peer->local' direction peering resource. If not specified defaults to `<name_prefix><peer network name>-<local network name>`. | `string` | `null` | no |
+| <a name="input_stack_type"></a> [stack\_type](#input\_stack\_type) | Which IP version(s) or routes are allowed to be imported or exported between peer networks. Possible values: `IPV4_ONLY` (default), `IPV4_IPV6`. | `string` | `null` | no |
 
 ### Outputs
 

--- a/modules/vpc-peering/main.tf
+++ b/modules/vpc-peering/main.tf
@@ -13,6 +13,7 @@ resource "google_compute_network_peering" "local" {
 
   export_subnet_routes_with_public_ip = var.local_export_subnet_routes_with_public_ip
   import_subnet_routes_with_public_ip = var.local_import_subnet_routes_with_public_ip
+  stack_type                          = var.stack_type
 }
 
 resource "google_compute_network_peering" "peer" {
@@ -25,4 +26,5 @@ resource "google_compute_network_peering" "peer" {
 
   export_subnet_routes_with_public_ip = var.peer_export_subnet_routes_with_public_ip
   import_subnet_routes_with_public_ip = var.peer_import_subnet_routes_with_public_ip
+  stack_type                          = var.stack_type
 }

--- a/modules/vpc-peering/variables.tf
+++ b/modules/vpc-peering/variables.tf
@@ -26,6 +26,12 @@ variable "name_prefix" {
   type        = string
 }
 
+variable "stack_type" {
+  description = "Which IP version(s) or routes are allowed to be imported or exported between peer networks. Possible values: `IPV4_ONLY` (default), `IPV4_IPV6`."
+  default     = null
+  type        = string
+}
+
 variable "local_export_custom_routes" {
   description = "Export custom routes setting for 'local->peer' direction."
   default     = false


### PR DESCRIPTION
## Description

IPv6 support is added via `stack_type` parameter.

## Motivation and Context

IPv6 might used for connectivity in the enterprise network. Because VM-Series is a part of the network, the deployment must support IPv6.

## How Has This Been Tested?

VM-Series deployment in a Common architecture.

## Screenshots (if appropriate)

n/a
## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
