### PR TITLE
fix(module/lb_external): Setting balancing_mode = CONNECTION due to provider changes

### DIFF
--- a/modules/lb_external/README.md
+++ b/modules/lb_external/README.md
@@ -8,6 +8,12 @@
   - Can only use the nic0 (the base interface) of an instance.
   - Cannot serve as a next hop in a GCP custom routing table entry.
 
+## Limitation
+
+### Supported Module Version with Regards to the Changed Provider's Default Values
+
+- Module versions `<=2.0.6` supports `terraform-provider-google` version `<6.0`. If you are using `terraform-provider-google` version `6.0` and above choose module version `2.0.7` and above. This limitation is related to the [change](https://github.com/hashicorp/terraform-provider-google/commit/267f964bd4f2d9b48e8771c2a8397de3f6655ef7) in the default value of `balancing_mode` introduced in the `terraform-provider-google` version `6.0` 
+
 ## Reference
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ### Requirements

--- a/modules/lb_external/main.tf
+++ b/modules/lb_external/main.tf
@@ -102,7 +102,8 @@ resource "google_compute_region_backend_service" "this" {
   dynamic "backend" {
     for_each = var.backend_instance_groups
     content {
-      group = backend.value
+      group          = backend.value
+      balancing_mode = "CONNECTION"
     }
   }
 


### PR DESCRIPTION
## Description

Set `google_compute_region_backend_service` `balancing_mode = "CONNECTION"` explicitly due to the [change](https://github.com/hashicorp/terraform-provider-google/commit/267f964bd4f2d9b48e8771c2a8397de3f6655ef7) in the `terraform-provider-google` version `6.0+` 

## Motivation and Context

Resolves #34 

## How Has This Been Tested?

Create a load balancer as part of Common architecture.

## Screenshots (if appropriate)

n/a

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
