### PR TITLE
added lifecycle ignore_change for boot_disk

### DIFF
--- a/modules/vmseries/main.tf
+++ b/modules/vmseries/main.tf
@@ -160,6 +160,10 @@ resource "google_compute_instance" "this" {
     }
   }
 
+  lifecycle {
+    ignore_changes = [boot_disk.0.initialize_params.0.image]
+  }
+
   depends_on = [
     null_resource.dependency_getter
   ]


### PR DESCRIPTION
Potential fix for #49 

## Description

To fix the issue with image change I haved added a lifecycle ignore_changes = [boot_disk.0.initialize_params.0.image]
for the vmseries module.
While might be solved in a better way. I have not found any better ways now. 
As already known referencing a module does not currently support lifecyle options,

## Motivation and Context

Changing the image variable for a newer version of PANos should NOT destroy what has already been created by terraform. This will fix this issue

I can't see any reasons why this should be an part of the module. 
Why would you want terraform to destroy an already created infrastructure using this module?
And if this is what you really want the destroy should be done with changing some other variables (region, number of vm's etc).

## How Has This Been Tested?

I tested in my own environment where I changed my current PANos image to something else.
With this fix terraform does not destroy any already created vm-series created.

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

lifecycle was added in the vmseries modules under google_compute_instance.




## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly. Not sure how this can be documented?!
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have added tests to cover my changes if appropriate.
- [ x] All new and existing tests passed.
