### PR TITLE
ci: Pin GitHub Actions

### DIFF
--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -36,7 +36,7 @@ jobs:
             return pr.data.head.ref
 
       - name: get PR source repository
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
         id: src-repo
         with:
           result-encoding: string
@@ -51,7 +51,7 @@ jobs:
       
       - name: Generate GitHub token
         id: generate-token
-        uses: tibdex/github-app-token@v2
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
         with:
           app_id: ${{ secrets.CHATOPS_APP_ID }}
           private_key: ${{ secrets.CHATOPS_APP_PRIVATE_KEY }}
@@ -60,7 +60,7 @@ jobs:
 
       - name: "dispatch test command on branch: ${{ steps.pr.outputs.result }}"
         id: scd
-        uses: peter-evans/slash-command-dispatch@v3
+        uses: peter-evans/slash-command-dispatch@f996d7b7aae9059759ac55e978cff76d91853301 # v3
         with:
           token: ${{ steps.generate-token.outputs.token }}
           issue-type: pull-request
@@ -92,7 +92,7 @@ jobs:
           
       - name: Concurency ratio fallback
         if: cancelled()
-        uses: peter-evans/create-or-update-comment@v3
+        uses: peter-evans/create-or-update-comment@23ff15729ef2fc348714a3bb66d2f655ca9066f2 # v3
         with:
           comment-id: ${{ github.event.comment.id }}
           body: |

--- a/.github/workflows/help-command.yml
+++ b/.github/workflows/help-command.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: add help comment
-        uses: peter-evans/create-or-update-comment@v3
+        uses: peter-evans/create-or-update-comment@23ff15729ef2fc348714a3bb66d2f655ca9066f2 # v3
         with:
           comment-id: ${{ inputs.comment-id }}
           issue-number: ${{ inputs.pr-id }}

--- a/.github/workflows/hub_sync.yml
+++ b/.github/workflows/hub_sync.yml
@@ -14,14 +14,14 @@ jobs:
     steps:
       - name: Generate GitHub token
         id: generate-token
-        uses: tibdex/github-app-token@v1
+        uses: tibdex/github-app-token@32691ba7c9e7063bd457bd8f2a5703138591fa58 # v1
         with:
           app_id: ${{ secrets.HUB_SYNC_APP_ID }}
           private_key: ${{ secrets.HUB_SYNC_APP_PRIVATE_KEY }}
           installation_id: ${{ secrets.HUB_SYNC_APP_INSTALLATION_ID }}
 
       - name: Trigger Hub Sync Workflow
-        uses: benc-uk/workflow-dispatch@v1
+        uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1
         with:
           workflow: run.yml
           repo: PaloAltoNetworks/automation-metadata-collector

--- a/.github/workflows/sca-command.yml
+++ b/.github/workflows/sca-command.yml
@@ -39,7 +39,7 @@ jobs:
       paths: ${{ steps.paths_reformat.outputs.paths }}
     steps:
       - name: add comment
-        uses: peter-evans/create-or-update-comment@v3
+        uses: peter-evans/create-or-update-comment@23ff15729ef2fc348714a3bb66d2f655ca9066f2 # v3
         with:
           comment-id: ${{ inputs.comment-id }}
           issue-number: ${{ inputs.pr-id }}


### PR DESCRIPTION
GitHub recommends pinning actions to a full length commit SHA, as this is currently the only method of using an action as an immutable release.

For more information refer to: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions