### PR TITLE
feat: A new feature to add CMEK attribute support to Panorama module

### DIFF
--- a/modules/panorama/main.tf
+++ b/modules/panorama/main.tf
@@ -77,6 +77,7 @@ resource "google_compute_instance" "this" {
       size  = var.disk_size
       type  = var.disk_type
     }
+    kms_key_self_link = var.cmek_key
   }
 
   dynamic "attached_disk" {

--- a/modules/panorama/variables.tf
+++ b/modules/panorama/variables.tf
@@ -115,6 +115,12 @@ variable "disk_size" {
   default     = null
 }
 
+variable "cmek_key" {
+  description = "CMEK key self-link used to encrypt the Panorama boot disk"
+  type        = string
+  default     = null
+}
+
 variable "ssh_keys" {
   description = <<EOF
   In order to connect via SSH to Panorama, provide your SSH public key here.


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The Panorama module creates Compute Engine instances without CMEK,
so it is incompatible with our security baseline.
The module needs to expose and apply a CMEK key for boot disks.
Fixes #88 - https://github.com/PaloAltoNetworks/terraform-google-swfw-modules/issues/881
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- terraform validate ✔️
- terraform plan ✔️
- tested with Panorama deployment ✔️
- - 

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
