### PR TITLE
feat: NSI and NCC modules and example

### DIFF
--- a/examples/vmseries_nsi/.header.md
+++ b/examples/vmseries_nsi/.header.md
@@ -1,0 +1,250 @@
+---
+short_title: VM-Series with Network Security Integration (NSI) and NCC
+type: example
+show_in_hub: true
+---
+# Reference Architecture with Terraform: VM-Series in GCP with Network Security Integration (NSI) and Network Connectivity Center (NCC)
+
+Palo Alto Networks produces several [validated reference architecture design and deployment documentation guides](https://www.paloaltonetworks.com/resources/reference-architectures), which describe well-architected and tested deployments. When deploying VM-Series in a public cloud, the reference architectures guide users toward the best security outcomes while reducing rollout time and avoiding common integration efforts.
+
+This Terraform example deploys Palo Alto Networks VM-Series firewalls in GCP using **Google Cloud Network Security Integration (NSI)** — a transparent, GENEVE-based traffic-interception mechanism that steers workload VPC traffic through the VM-Series fleet for deep-packet inspection, without changing routes, VPC peerings, or workload VM configurations. It also deploys **Network Connectivity Center (NCC)** to provide transitive hub-and-spoke connectivity between workload VPCs.
+
+## Reference Architecture Design
+
+The deployment implements a centralized security model in which a dedicated producer/security VPC hosts the VM-Series fleet, and one or more consumer/spoke VPCs have their traffic transparently intercepted and inspected.
+
+This architecture is particularly suited for:
+- East-west traffic inspection between spoke VPCs without additional hops or route policy changes.
+- Scalable security for many consumer VPCs using a single VM-Series fleet.
+- Environments where workload teams manage their own VPCs and do not want to manage routes or peerings.
+
+## Detailed Architecture and Design
+
+### Network Security Integration (NSI)
+
+NSI uses a two-sided model:
+
+**Producer side** (inside the security/producer VPC):
+
+1. **GENEVE ILB** — one Internal Passthrough Network Load Balancer per zone, listening on UDP/6081. The VM-Series receive GENEVE-encapsulated copies of intercepted flows on this interface.
+2. **Intercept deployment** — one `google_network_security_intercept_deployment` per zone, referencing the zone-specific ILB forwarding rule. This zone-level resource is what requires a unique forwarding rule per zone.
+3. **Intercept deployment group** — a single global resource that aggregates all zonal deployments for the producer VPC.
+4. **Intercept endpoint group** — the logical handle that consumer associations reference; links the consumer intercept request to the deployment group.
+5. **Security profile + group** — the policy object that maps the endpoint group to PAN-OS for inspection.
+
+**Consumer side** (inside each workload/spoke VPC):
+
+6. **Intercept endpoint group association** — activates NSI interception for the consumer VPC. Each association can take **5–15 minutes to reach `ACTIVE` state** on first apply.
+7. **Global network firewall policy** — rules with `action = apply_security_profile_group` steer matched flows into NSI. Both ingress and egress rules are configured by default.
+8. **Firewall policy association** — attaches the policy to the consumer VPC network.
+
+### Network Connectivity Center (NCC)
+
+NCC provides transitive hub-and-spoke routing between consumer VPCs without requiring explicit VPC peerings between each pair. The NCC hub uses **MESH** topology by default, which lets all spokes exchange routes and reach one another through the hub. Combined with NSI, this means inter-spoke traffic is transparently intercepted and inspected by VM-Series as it transits the NCC routing plane.
+
+### Bootstrap
+
+The VM-Series use **metadata-only bootstrap** (no GCS bucket required). The mandatory `plugin-op-commands = "geneve-inspect:enable"` option is automatically merged into every instance's bootstrap metadata by the `main.tf` and activates GENEVE decapsulation on PAN-OS 11.2+.
+
+### Default Topology
+
+With the provided `example.tfvars`, the deployment creates:
+
+- 1 producer/security VPC with `mgmt` and `data` subnets
+- 2 VM-Series firewalls (`n2-standard-8`) — one in `us-central1-a`, one in `us-central1-b`
+- 2 GENEVE ILBs (one per zone, UDP/6081)
+- 1 NSI intercept stack (deployment group, endpoint group, security profile + group)
+- 2 consumer/spoke VPCs (`spoke-1`, `spoke-2`), each with an NSI endpoint-group association and a global firewall policy
+- 1 NCC hub in MESH topology with 2 VPC spokes
+- 2 optional Linux test VMs (one per spoke, for end-to-end validation)
+
+## Prerequisites
+
+Before deploying, ensure the following:
+
+1. **PAN-OS image** — the `vmseries_image` must be PAN-OS **≥ 11.2** (e.g. `vmseries-flex-byol-1120`). NSI GENEVE decapsulation is not available on earlier releases.
+
+2. **GCP APIs** — enable the following APIs in your project:
+   ```
+   gcloud services enable \
+     compute.googleapis.com \
+     networksecurity.googleapis.com \
+     networkconnectivity.googleapis.com \
+     iam.googleapis.com
+   ```
+
+3. **GCP authentication** — configure the [Google Terraform provider](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#authentication-configuration).
+
+4. **Panorama (optional)** — if using Panorama-managed bootstrap, ensure Panorama is reachable from the `mgmt` subnet and fill in `panorama-server`, `tplname`, `dgname`, and `vm-auth-key` under `vmseries_common.bootstrap_options`.
+
+5. **VM-Series license** — prepare [VM-Series licenses](https://support.paloaltonetworks.com/) or use an evaluation image.
+
+## Usage
+
+1. Access Google Cloud Shell or any environment with access to your GCP project.
+
+2. Clone the repository:
+   ```
+   git clone https://github.com/PaloAltoNetworks/terraform-google-swfw-modules
+   cd terraform-google-swfw-modules/examples/vmseries_nsi
+   ```
+
+3. Copy `example.tfvars` to `terraform.tfvars` and update the required values:
+   ```
+   cp example.tfvars terraform.tfvars
+   ```
+   At minimum, update:
+   - `project` — your GCP project ID
+   - `ssh_keys` — your SSH public key
+   - `vmseries_image` — a PAN-OS ≥ 11.2 image name available in your project
+   - `vmseries_common.bootstrap_options.panorama-server` — your Panorama IP (or leave empty for standalone bootstrap)
+   - `producer_vpc.firewall_rules.allow-mgmt-ssh-https.source_ranges` — your operator/jump-host CIDRs
+
+4. Deploy:
+   ```
+   terraform init
+   terraform apply
+   ```
+
+5. Confirm the plan and approve. The apply takes **10–20 minutes** — longer than typical because the `intercept_endpoint_group_association` resources wait for GCP to activate the NSI intercept path for each consumer VPC.
+
+## Expected Outputs
+
+After a successful `terraform apply`, you should see output similar to:
+
+```
+Apply complete! Resources: 44 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+geneve_ilb_addresses = {
+  "fw-01" = "10.0.1.10"
+  "fw-02" = "10.0.1.11"
+}
+linux_vm_ips = {
+  "spoke1-vm" = "192.168.1.2"
+  "spoke2-vm" = "192.168.2.2"
+}
+ncc_hub_id      = "projects/<PROJECT>/locations/global/hubs/pan-nsi-ncc-hub"
+ncc_spoke_names = {
+  "spoke-1" = "pan-nsi-spoke-spoke-1"
+  "spoke-2" = "pan-nsi-spoke-spoke-2"
+}
+nsi_deployment_group_id       = "projects/<PROJECT>/locations/global/interceptDeploymentGroups/pan-nsi-intercept-dgrp"
+nsi_endpoint_group_id         = "projects/<PROJECT>/locations/global/interceptEndpointGroups/pan-nsi-intercept-egrp"
+nsi_security_profile_group_id = "//networksecurity.googleapis.com/projects/<PROJECT>/locations/global/securityProfileGroups/pan-nsi-intercept-pgrp"
+vmseries_private_ips = {
+  "fw-01" = { "0" = "10.0.0.2", "1" = "10.0.1.2" }
+  "fw-02" = { "0" = "10.0.0.3", "1" = "10.0.1.3" }
+}
+vmseries_public_ips = {
+  "fw-01" = {}
+  "fw-02" = {}
+}
+```
+
+## Post-Build: VM-Series Bootstrap Verification
+
+Connect to each VM-Series instance via SSH using your private key and verify the bootstrap completed successfully:
+
+```
+ssh admin@<MGMT_IP> -i /path/to/your/private_key
+```
+
+Wait up to 10–15 minutes for the bootstrap to finish. The key indicator is `Auto-commit Successful`:
+
+```
+admin@PA-VM> show system bootstrap status
+
+Bootstrap Phase               Status         Details
+===============               ======         =======
+Media Detection               Success        Media detected successfully
+Media Sanity Check            Success        Media sanity check successful
+Parsing of Initial Config     Successful
+Auto-commit                   Successful
+```
+
+Set the admin password:
+
+```
+admin@PA-VM> configure
+[edit]
+admin@PA-VM# set mgt-config users admin password
+Enter password   :
+Confirm password :
+
+[edit]
+admin@PA-VM# commit
+Configuration committed successfully
+```
+
+If `create_mgmt_public_ip = false`, use IAP tunneling to reach the management IP:
+
+```
+gcloud compute ssh <NAME-PREFIX>fw-01 --zone=us-central1-a --tunnel-through-iap
+```
+
+## Post-Build: PAN-OS GENEVE Health-Check Configuration
+
+For the GENEVE ILBs to mark the VM-Series backends as healthy, you must configure a **loopback interface** per ILB forwarding rule IP with an HTTPS management profile that allows the GCP health-check source ranges.
+
+For each IP address in the `geneve_ilb_addresses` output:
+
+1. In PAN-OS, go to **Network → Interfaces → Loopback** and add a loopback interface with the ILB IP as its address.
+2. Create a **Management Profile** that allows HTTPS from these GCP health-check ranges:
+   - `35.191.0.0/16`
+   - `130.211.0.0/22`
+   - `209.85.152.0/22`
+   - `209.85.204.0/22`
+3. Assign the management profile to the loopback interface.
+4. Commit the configuration on both firewalls.
+
+Once healthy, confirm the backend status from the CLI:
+
+```
+gcloud compute backend-services get-health pan-nsi-geneve-ilb-fw-01-bs --region us-central1
+```
+
+You should see `healthState: HEALTHY` for both instances.
+
+## Verify NSI Interception End-to-End
+
+After the health checks pass, verify that traffic between consumer VMs is intercepted by VM-Series.
+
+1. SSH into the `spoke1-vm` test VM via IAP:
+   ```
+   gcloud compute ssh pan-nsi-spoke1-vm --zone=us-central1-a --tunnel-through-iap
+   ```
+
+2. From `spoke1-vm`, curl the `spoke2-vm` internal IP (from `linux_vm_ips` output):
+   ```
+   curl http://192.168.2.2
+   ```
+   You should receive the `spoke-2-vm` response from the nginx startup script.
+
+3. In PAN-OS, go to **Monitor → Traffic** and confirm the flow appears. The source IP will be `192.168.1.2` (spoke1-vm) and the destination will be `192.168.2.2` (spoke2-vm). The traffic should be logged as inspected, confirming NSI is steering spoke-to-spoke traffic through PAN-OS.
+
+## Verify NCC Hub and Spoke Connectivity
+
+Confirm the NCC hub and spokes are in `ACTIVE` state:
+
+```
+gcloud network-connectivity hubs describe pan-nsi-ncc-hub --project <PROJECT>
+
+gcloud network-connectivity spokes list \
+  --hub=pan-nsi-ncc-hub \
+  --global \
+  --project <PROJECT>
+```
+
+Both spokes should show `state: ACTIVE`. The NCC mesh routing is what enables `spoke1-vm` to reach `spoke2-vm` without any explicit VPC peering between the two spoke VPCs.
+
+## Cleanup
+
+To destroy all resources:
+
+```
+terraform destroy
+```
+
+> **Note:** The `intercept_endpoint_group_association` resources can take several minutes to fully delete after `terraform destroy` completes. If you re-apply with the same `name_prefix` immediately after a destroy, you may encounter a conflict on the association resource names. Wait a few minutes before re-applying.

--- a/examples/vmseries_nsi/README.md
+++ b/examples/vmseries_nsi/README.md
@@ -1,0 +1,598 @@
+---
+short_title: VM-Series with Network Security Integration (NSI) and NCC
+type: example
+show_in_hub: true
+---
+# Reference Architecture with Terraform: VM-Series in GCP with Network Security Integration (NSI) and Network Connectivity Center (NCC)
+
+Palo Alto Networks produces several [validated reference architecture design and deployment documentation guides](https://www.paloaltonetworks.com/resources/reference-architectures), which describe well-architected and tested deployments. When deploying VM-Series in a public cloud, the reference architectures guide users toward the best security outcomes while reducing rollout time and avoiding common integration efforts.
+
+This Terraform example deploys Palo Alto Networks VM-Series firewalls in GCP using **Google Cloud Network Security Integration (NSI)** — a transparent, GENEVE-based traffic-interception mechanism that steers workload VPC traffic through the VM-Series fleet for deep-packet inspection, without changing routes, VPC peerings, or workload VM configurations. It also deploys **Network Connectivity Center (NCC)** to provide transitive hub-and-spoke connectivity between workload VPCs.
+
+## Reference Architecture Design
+
+The deployment implements a centralized security model in which a dedicated producer/security VPC hosts the VM-Series fleet, and one or more consumer/spoke VPCs have their traffic transparently intercepted and inspected.
+
+This architecture is particularly suited for:
+- East-west traffic inspection between spoke VPCs without additional hops or route policy changes.
+- Scalable security for many consumer VPCs using a single VM-Series fleet.
+- Environments where workload teams manage their own VPCs and do not want to manage routes or peerings.
+
+## Detailed Architecture and Design
+
+### Network Security Integration (NSI)
+
+NSI uses a two-sided model:
+
+**Producer side** (inside the security/producer VPC):
+
+1. **GENEVE ILB** — one Internal Passthrough Network Load Balancer per zone, listening on UDP/6081. The VM-Series receive GENEVE-encapsulated copies of intercepted flows on this interface.
+2. **Intercept deployment** — one `google_network_security_intercept_deployment` per zone, referencing the zone-specific ILB forwarding rule. This zone-level resource is what requires a unique forwarding rule per zone.
+3. **Intercept deployment group** — a single global resource that aggregates all zonal deployments for the producer VPC.
+4. **Intercept endpoint group** — the logical handle that consumer associations reference; links the consumer intercept request to the deployment group.
+5. **Security profile + group** — the policy object that maps the endpoint group to PAN-OS for inspection.
+
+**Consumer side** (inside each workload/spoke VPC):
+
+6. **Intercept endpoint group association** — activates NSI interception for the consumer VPC. Each association can take **5–15 minutes to reach `ACTIVE` state** on first apply.
+7. **Global network firewall policy** — rules with `action = apply_security_profile_group` steer matched flows into NSI. Both ingress and egress rules are configured by default.
+8. **Firewall policy association** — attaches the policy to the consumer VPC network.
+
+### Network Connectivity Center (NCC)
+
+NCC provides transitive hub-and-spoke routing between consumer VPCs without requiring explicit VPC peerings between each pair. The NCC hub uses **MESH** topology by default, which lets all spokes exchange routes and reach one another through the hub. Combined with NSI, this means inter-spoke traffic is transparently intercepted and inspected by VM-Series as it transits the NCC routing plane.
+
+### Bootstrap
+
+The VM-Series use **metadata-only bootstrap** (no GCS bucket required). The mandatory `plugin-op-commands = "geneve-inspect:enable"` option is automatically merged into every instance's bootstrap metadata by the `main.tf` and activates GENEVE decapsulation on PAN-OS 11.2+.
+
+### Default Topology
+
+With the provided `example.tfvars`, the deployment creates:
+
+- 1 producer/security VPC with `mgmt` and `data` subnets
+- 2 VM-Series firewalls (`n2-standard-8`) — one in `us-central1-a`, one in `us-central1-b`
+- 2 GENEVE ILBs (one per zone, UDP/6081)
+- 1 NSI intercept stack (deployment group, endpoint group, security profile + group)
+- 2 consumer/spoke VPCs (`spoke-1`, `spoke-2`), each with an NSI endpoint-group association and a global firewall policy
+- 1 NCC hub in MESH topology with 2 VPC spokes
+- 2 optional Linux test VMs (one per spoke, for end-to-end validation)
+
+## Prerequisites
+
+Before deploying, ensure the following:
+
+1. **PAN-OS image** — the `vmseries_image` must be PAN-OS **≥ 11.2** (e.g. `vmseries-flex-byol-1120`). NSI GENEVE decapsulation is not available on earlier releases.
+
+2. **GCP APIs** — enable the following APIs in your project:
+   ```
+   gcloud services enable \
+     compute.googleapis.com \
+     networksecurity.googleapis.com \
+     networkconnectivity.googleapis.com \
+     iam.googleapis.com
+   ```
+
+3. **GCP authentication** — configure the [Google Terraform provider](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#authentication-configuration).
+
+4. **Panorama (optional)** — if using Panorama-managed bootstrap, ensure Panorama is reachable from the `mgmt` subnet and fill in `panorama-server`, `tplname`, `dgname`, and `vm-auth-key` under `vmseries_common.bootstrap_options`.
+
+5. **VM-Series license** — prepare [VM-Series licenses](https://support.paloaltonetworks.com/) or use an evaluation image.
+
+## Usage
+
+1. Access Google Cloud Shell or any environment with access to your GCP project.
+
+2. Clone the repository:
+   ```
+   git clone https://github.com/PaloAltoNetworks/terraform-google-swfw-modules
+   cd terraform-google-swfw-modules/examples/vmseries_nsi
+   ```
+
+3. Copy `example.tfvars` to `terraform.tfvars` and update the required values:
+   ```
+   cp example.tfvars terraform.tfvars
+   ```
+   At minimum, update:
+   - `project` — your GCP project ID
+   - `ssh_keys` — your SSH public key
+   - `vmseries_image` — a PAN-OS ≥ 11.2 image name available in your project
+   - `vmseries_common.bootstrap_options.panorama-server` — your Panorama IP (or leave empty for standalone bootstrap)
+   - `producer_vpc.firewall_rules.allow-mgmt-ssh-https.source_ranges` — your operator/jump-host CIDRs
+
+4. Deploy:
+   ```
+   terraform init
+   terraform apply
+   ```
+
+5. Confirm the plan and approve. The apply takes **10–20 minutes** — longer than typical because the `intercept_endpoint_group_association` resources wait for GCP to activate the NSI intercept path for each consumer VPC.
+
+## Expected Outputs
+
+After a successful `terraform apply`, you should see output similar to:
+
+```
+Apply complete! Resources: 44 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+geneve_ilb_addresses = {
+  "fw-01" = "10.0.1.10"
+  "fw-02" = "10.0.1.11"
+}
+linux_vm_ips = {
+  "spoke1-vm" = "192.168.1.2"
+  "spoke2-vm" = "192.168.2.2"
+}
+ncc_hub_id      = "projects/<PROJECT>/locations/global/hubs/pan-nsi-ncc-hub"
+ncc_spoke_names = {
+  "spoke-1" = "pan-nsi-spoke-spoke-1"
+  "spoke-2" = "pan-nsi-spoke-spoke-2"
+}
+nsi_deployment_group_id       = "projects/<PROJECT>/locations/global/interceptDeploymentGroups/pan-nsi-intercept-dgrp"
+nsi_endpoint_group_id         = "projects/<PROJECT>/locations/global/interceptEndpointGroups/pan-nsi-intercept-egrp"
+nsi_security_profile_group_id = "//networksecurity.googleapis.com/projects/<PROJECT>/locations/global/securityProfileGroups/pan-nsi-intercept-pgrp"
+vmseries_private_ips = {
+  "fw-01" = { "0" = "10.0.0.2", "1" = "10.0.1.2" }
+  "fw-02" = { "0" = "10.0.0.3", "1" = "10.0.1.3" }
+}
+vmseries_public_ips = {
+  "fw-01" = {}
+  "fw-02" = {}
+}
+```
+
+## Post-Build: VM-Series Bootstrap Verification
+
+Connect to each VM-Series instance via SSH using your private key and verify the bootstrap completed successfully:
+
+```
+ssh admin@<MGMT_IP> -i /path/to/your/private_key
+```
+
+Wait up to 10–15 minutes for the bootstrap to finish. The key indicator is `Auto-commit Successful`:
+
+```
+admin@PA-VM> show system bootstrap status
+
+Bootstrap Phase               Status         Details
+===============               ======         =======
+Media Detection               Success        Media detected successfully
+Media Sanity Check            Success        Media sanity check successful
+Parsing of Initial Config     Successful
+Auto-commit                   Successful
+```
+
+Set the admin password:
+
+```
+admin@PA-VM> configure
+[edit]
+admin@PA-VM# set mgt-config users admin password
+Enter password   :
+Confirm password :
+
+[edit]
+admin@PA-VM# commit
+Configuration committed successfully
+```
+
+If `create_mgmt_public_ip = false`, use IAP tunneling to reach the management IP:
+
+```
+gcloud compute ssh <NAME-PREFIX>fw-01 --zone=us-central1-a --tunnel-through-iap
+```
+
+## Post-Build: PAN-OS GENEVE Health-Check Configuration
+
+For the GENEVE ILBs to mark the VM-Series backends as healthy, you must configure a **loopback interface** per ILB forwarding rule IP with an HTTPS management profile that allows the GCP health-check source ranges.
+
+For each IP address in the `geneve_ilb_addresses` output:
+
+1. In PAN-OS, go to **Network → Interfaces → Loopback** and add a loopback interface with the ILB IP as its address.
+2. Create a **Management Profile** that allows HTTPS from these GCP health-check ranges:
+   - `35.191.0.0/16`
+   - `130.211.0.0/22`
+   - `209.85.152.0/22`
+   - `209.85.204.0/22`
+3. Assign the management profile to the loopback interface.
+4. Commit the configuration on both firewalls.
+
+Once healthy, confirm the backend status from the CLI:
+
+```
+gcloud compute backend-services get-health pan-nsi-geneve-ilb-fw-01-bs --region us-central1
+```
+
+You should see `healthState: HEALTHY` for both instances.
+
+## Verify NSI Interception End-to-End
+
+After the health checks pass, verify that traffic between consumer VMs is intercepted by VM-Series.
+
+1. SSH into the `spoke1-vm` test VM via IAP:
+   ```
+   gcloud compute ssh pan-nsi-spoke1-vm --zone=us-central1-a --tunnel-through-iap
+   ```
+
+2. From `spoke1-vm`, curl the `spoke2-vm` internal IP (from `linux_vm_ips` output):
+   ```
+   curl http://192.168.2.2
+   ```
+   You should receive the `spoke-2-vm` response from the nginx startup script.
+
+3. In PAN-OS, go to **Monitor → Traffic** and confirm the flow appears. The source IP will be `192.168.1.2` (spoke1-vm) and the destination will be `192.168.2.2` (spoke2-vm). The traffic should be logged as inspected, confirming NSI is steering spoke-to-spoke traffic through PAN-OS.
+
+## Verify NCC Hub and Spoke Connectivity
+
+Confirm the NCC hub and spokes are in `ACTIVE` state:
+
+```
+gcloud network-connectivity hubs describe pan-nsi-ncc-hub --project <PROJECT>
+
+gcloud network-connectivity spokes list \
+  --hub=pan-nsi-ncc-hub \
+  --global \
+  --project <PROJECT>
+```
+
+Both spokes should show `state: ACTIVE`. The NCC mesh routing is what enables `spoke1-vm` to reach `spoke2-vm` without any explicit VPC peering between the two spoke VPCs.
+
+## Cleanup
+
+To destroy all resources:
+
+```
+terraform destroy
+```
+
+> **Note:** The `intercept_endpoint_group_association` resources can take several minutes to fully delete after `terraform destroy` completes. If you re-apply with the same `name_prefix` immediately after a destroy, you may encounter a conflict on the association resource names. Wait a few minutes before re-applying.
+
+## Reference
+
+### Requirements
+
+- `terraform`, version: >= 1.3, < 2.0
+- `google`, version: >= 6.15
+- `google-beta`, version: >= 6.15
+
+### Providers
+
+- `google`, version: >= 6.15
+
+### Modules
+Name | Version | Source | Description
+--- | --- | --- | ---
+`consumer_vpcs` | - | ../../modules/vpc | 
+`data_vpc` | - | ../../modules/vpc | 
+`geneve_ilb` | - | ../../modules/lb_internal | 
+`iam_service_account` | - | ../../modules/iam_service_account | 
+`mgmt_vpc` | - | ../../modules/vpc | 
+`ncc` | - | ../../modules/ncc_connectivity | 
+`nsi` | - | ../../modules/nsi_intercept | 
+`vmseries` | - | ../../modules/vmseries | 
+
+### Resources
+
+- `compute_instance` (managed)
+- `compute_region_health_check` (managed)
+
+### Required Inputs
+
+Name | Type | Description
+--- | --- | ---
+[`consumer_vpcs`](#consumer_vpcs) | `map` | Map of consumer/spoke VPC key => VPC and subnet configuration.
+[`data_vpc`](#data_vpc) | `object` | Data/GENEVE VPC for VM-Series NIC1.
+[`mgmt_vpc`](#mgmt_vpc) | `object` | Management VPC for VM-Series NIC0.
+[`name_prefix`](#name_prefix) | `string` | Short prefix applied to every resource name (e.
+[`project`](#project) | `string` | GCP project ID for all resources.
+[`region`](#region) | `string` | GCP region for subnets, ILBs, and Cloud Router.
+[`ssh_keys`](#ssh_keys) | `string` | SSH public key(s) for instance-level access (format: "user:ssh-ed25519 AAAA.
+[`vmseries`](#vmseries) | `map` | Map of VM-Series instance key => zone and per-instance bootstrap overrides.
+[`vmseries_image`](#vmseries_image) | `string` | Full VM-Series image name.
+
+### Optional Inputs
+
+Name | Type | Description
+--- | --- | ---
+[`create_mgmt_public_ip`](#create_mgmt_public_ip) | `bool` | Assign a public IP to the mgmt NIC.
+[`enable_ncc`](#enable_ncc) | `bool` | Deploy a Network Connectivity Center hub and attach each consumer VPC as a spoke.
+[`firewall_policy_rules`](#firewall_policy_rules) | `list` | Firewall policy rules applied to each consumer VPC.
+[`linux_vms`](#linux_vms) | `map` | Optional Linux test VMs to deploy in consumer VPCs for validating NSI traffic interception end-to-end.
+[`ncc_topology`](#ncc_topology) | `string` | NCC hub preset topology.
+[`service_account`](#service_account) | `object` | Service account configuration for the VM-Series instances.
+[`vmseries_common`](#vmseries_common) | `object` | Common settings shared across all VM-Series instances.
+
+### Outputs
+
+Name |  Description
+--- | ---
+`geneve_ilb_addresses` | Map of VM-Series instance key => internal IP address of the per-zone GENEVE ILB forwarding rule.
+`linux_vm_ips` | Map of Linux VM key => internal IP address (populated only when linux_vms is configured).
+`ncc_hub_id` | Full resource ID of the NCC hub (null when enable_ncc = false).
+`ncc_spoke_names` | Map of consumer VPC key => NCC spoke resource name (empty when enable_ncc = false).
+`nsi_deployment_group_id` | Full resource ID of the NSI intercept deployment group.
+`nsi_endpoint_group_id` | Full resource ID of the NSI intercept endpoint group.
+`nsi_security_profile_group_id` | Full resource ID of the NSI security profile group.
+`vmseries_private_ips` | Map of VM-Series instance key => map of NIC index => private IP address.
+`vmseries_public_ips` | Map of VM-Series instance key => map of NIC index => public IP address (null when not created).
+
+### Required Inputs details
+
+#### consumer_vpcs
+
+Map of consumer/spoke VPC key => VPC and subnet configuration. Each entry gets one NCC spoke and one NSI endpoint-group association.
+
+Type: 
+
+```hcl
+map(object({
+    name            = string
+    subnetwork_name = string
+    ip_cidr_range   = string
+    firewall_rules = optional(map(object({
+      name             = string
+      source_ranges    = optional(list(string))
+      source_tags      = optional(list(string))
+      allowed_protocol = string
+      allowed_ports    = optional(list(string), [])
+      priority         = optional(number, 1000)
+    })), {})
+    firewall_policy_rules = optional(list(object({
+      priority    = number
+      direction   = string
+      description = optional(string, "")
+      match = object({
+        src_ip_ranges  = optional(list(string), [])
+        dest_ip_ranges = optional(list(string), [])
+        layer4_configs = list(object({
+          ip_protocol = string
+          ports       = optional(list(string), [])
+        }))
+      })
+    })), null)
+  }))
+```
+
+
+<sup>[back to list](#modules-required-inputs)</sup>
+
+#### data_vpc
+
+Data/GENEVE VPC for VM-Series NIC1. The GENEVE ILB and NSI intercept deployment group live here.
+
+Type: 
+
+```hcl
+object({
+    name            = string
+    subnetwork_name = string
+    ip_cidr_range   = string
+    firewall_rules = optional(map(object({
+      name             = string
+      source_ranges    = optional(list(string))
+      source_tags      = optional(list(string))
+      allowed_protocol = string
+      allowed_ports    = optional(list(string), [])
+      priority         = optional(number, 1000)
+    })), {})
+  })
+```
+
+
+<sup>[back to list](#modules-required-inputs)</sup>
+
+#### mgmt_vpc
+
+Management VPC for VM-Series NIC0. Kept separate from data_vpc so GCP health checks target NIC1.
+
+Type: 
+
+```hcl
+object({
+    name            = string
+    subnetwork_name = string
+    ip_cidr_range   = string
+    firewall_rules = optional(map(object({
+      name             = string
+      source_ranges    = optional(list(string))
+      source_tags      = optional(list(string))
+      allowed_protocol = string
+      allowed_ports    = optional(list(string), [])
+      priority         = optional(number, 1000)
+    })), {})
+  })
+```
+
+
+<sup>[back to list](#modules-required-inputs)</sup>
+
+#### name_prefix
+
+Short prefix applied to every resource name (e.g. "pan-nsi-").
+
+Type: string
+
+<sup>[back to list](#modules-required-inputs)</sup>
+
+#### project
+
+GCP project ID for all resources.
+
+Type: string
+
+<sup>[back to list](#modules-required-inputs)</sup>
+
+#### region
+
+GCP region for subnets, ILBs, and Cloud Router.
+
+Type: string
+
+<sup>[back to list](#modules-required-inputs)</sup>
+
+#### ssh_keys
+
+SSH public key(s) for instance-level access (format: "user:ssh-ed25519 AAAA... user@host").
+
+Type: string
+
+<sup>[back to list](#modules-required-inputs)</sup>
+
+#### vmseries
+
+Map of VM-Series instance key => zone and per-instance bootstrap overrides.
+Typically two entries (one per zone) for zone-redundant active-active deployment.
+The module forces `plugin-op-commands = "geneve-inspect:enable"` in the merged
+bootstrap_options regardless of what is set here.
+Each entry must use a unique zone — NSI requires one ILB forwarding rule per zone,
+and the example maps zone => forwarding rule one-to-one.
+
+
+Type: 
+
+```hcl
+map(object({
+    zone              = string
+    bootstrap_options = optional(map(string), {})
+  }))
+```
+
+
+<sup>[back to list](#modules-required-inputs)</sup>
+
+#### vmseries_image
+
+Full VM-Series image name. Must be PAN-OS >= 11.2 for NSI GENEVE support (e.g. "vmseries-flex-byol-1120").
+
+Type: string
+
+<sup>[back to list](#modules-required-inputs)</sup>
+
+### Optional Inputs details
+
+#### create_mgmt_public_ip
+
+Assign a public IP to the mgmt NIC. Set true in lab environments for direct SSH/HTTPS access.
+
+Type: bool
+
+Default value: `false`
+
+<sup>[back to list](#modules-optional-inputs)</sup>
+
+#### enable_ncc
+
+Deploy a Network Connectivity Center hub and attach each consumer VPC as a spoke. When true, all consumer VPCs gain transitive (MESH) routing through the hub, which NSI then inspects. Set false to skip NCC entirely and manage connectivity separately.
+
+Type: bool
+
+Default value: `true`
+
+<sup>[back to list](#modules-optional-inputs)</sup>
+
+#### firewall_policy_rules
+
+Firewall policy rules applied to each consumer VPC. The nsi_intercept module sets action=apply_security_profile_group automatically.
+
+Type: 
+
+```hcl
+list(object({
+    priority    = number
+    direction   = string
+    description = optional(string, "")
+    match = object({
+      src_ip_ranges  = optional(list(string), [])
+      dest_ip_ranges = optional(list(string), [])
+      layer4_configs = list(object({
+        ip_protocol = string
+        ports       = optional(list(string), [])
+      }))
+    })
+  }))
+```
+
+
+Default value: `[map[description:Intercept all egress for PAN-OS inspection direction:EGRESS match:map[dest_ip_ranges:[0.0.0.0/0] layer4_configs:[map[ip_protocol:all]]] priority:1000] map[description:Intercept all ingress for PAN-OS inspection direction:INGRESS match:map[layer4_configs:[map[ip_protocol:all]] src_ip_ranges:[0.0.0.0/0]] priority:1001]]`
+
+<sup>[back to list](#modules-optional-inputs)</sup>
+
+#### linux_vms
+
+Optional Linux test VMs to deploy in consumer VPCs for validating NSI traffic interception end-to-end.
+
+Type: 
+
+```hcl
+map(object({
+    zone                    = string
+    consumer_vpc_key        = string
+    machine_type            = optional(string, "e2-micro")
+    disk_size_gb            = optional(number, 20)
+    metadata_startup_script = optional(string, null)
+  }))
+```
+
+
+Default value: `map[]`
+
+<sup>[back to list](#modules-optional-inputs)</sup>
+
+#### ncc_topology
+
+NCC hub preset topology. MESH allows all spokes to reach each other; STAR requires designating center spokes.
+
+Type: string
+
+Default value: `MESH`
+
+<sup>[back to list](#modules-optional-inputs)</sup>
+
+#### service_account
+
+Service account configuration for the VM-Series instances.
+
+Type: 
+
+```hcl
+object({
+    service_account_id = string
+    roles              = list(string)
+  })
+```
+
+
+Default value: `map[roles:[roles/compute.networkViewer roles/logging.logWriter roles/monitoring.metricWriter roles/monitoring.viewer roles/stackdriver.accounts.viewer roles/stackdriver.resourceMetadata.writer] service_account_id:sa-ngfw-vmseries]`
+
+<sup>[back to list](#modules-optional-inputs)</sup>
+
+#### vmseries_common
+
+Common settings shared across all VM-Series instances.
+The bootstrap option `plugin-op-commands = "geneve-inspect:enable"` is always
+merged in automatically — do not include it here as it would be overwritten.
+
+
+Type: 
+
+```hcl
+object({
+    machine_type     = optional(string, "n2-standard-8")
+    min_cpu_platform = optional(string, "Intel Cascade Lake")
+    bootstrap_options = optional(map(string), {
+      type                        = "dhcp-client"
+      dhcp-send-client-id         = "yes"
+      dhcp-accept-server-hostname = "yes"
+      dhcp-accept-server-domain   = "yes"
+      dns-primary                 = "169.254.169.254"
+      panorama-server             = ""
+    })
+  })
+```
+
+
+Default value: `map[]`
+
+<sup>[back to list](#modules-optional-inputs)</sup>

--- a/examples/vmseries_nsi/example.tfvars
+++ b/examples/vmseries_nsi/example.tfvars
@@ -1,0 +1,171 @@
+project     = "your-gcp-project-id"
+region      = "us-central1"
+name_prefix = "pan-nsi-"
+
+# Set true to assign public IPs to the VM-Series mgmt NICs (lab only).
+create_mgmt_public_ip = false
+
+# Replace with your SSH public key.
+ssh_keys = "ssh-ed25519 AAAA... admin@example.com"
+
+# PAN-OS >= 11.2 is required for NSI GENEVE support.
+vmseries_image = "vmseries-flex-byol-1120"
+
+vmseries_common = {
+  machine_type     = "n2-standard-8"
+  min_cpu_platform = "Intel Cascade Lake"
+  bootstrap_options = {
+    type                        = "dhcp-client"
+    dhcp-send-client-id         = "yes"
+    dhcp-accept-server-hostname = "yes"
+    dhcp-accept-server-domain   = "yes"
+    dns-primary                 = "169.254.169.254"
+    panorama-server             = "10.0.0.1"    # Replace with your Panorama IP
+    tplname                     = "tpl-nsi-dev" # Panorama Template Stack name
+    dgname                      = "dg-nsi-dev"  # Panorama Device Group name
+    vm-auth-key                 = ""            # Generate with: request bootstrap vm-auth-key generate lifetime 8760
+    # plugin-op-commands is automatically set to "geneve-inspect:enable" by the example
+  }
+}
+
+# Two VM-Series instances, one per zone (active-active, no PAN-OS HA1/HA2).
+vmseries = {
+  fw-01 = { zone = "us-central1-a" }
+  fw-02 = { zone = "us-central1-b" }
+}
+
+# Management VPC — NIC0 only. Kept in a separate VPC from data_vpc so that
+# GCP's internal LB health checks target NIC1 (the GENEVE data interface).
+mgmt_vpc = {
+  name            = "pan-nsi-mgmt-vpc"
+  subnetwork_name = "pan-nsi-mgmt-subnet"
+  ip_cidr_range   = "10.0.0.0/24"
+  firewall_rules = {
+    allow-mgmt = {
+      name             = "pan-nsi-allow-mgmt"
+      source_ranges    = ["0.0.0.0/0"] # Replace with your operator CIDRs
+      allowed_protocol = "tcp"
+      allowed_ports    = ["22", "443", "3978"]
+      priority         = 1000
+    }
+  }
+}
+
+# Data VPC — NIC1 / GENEVE ILB / NSI intercept deployment group.
+# GCP health check ranges are allowed here so probes reach ethernet1/1.
+data_vpc = {
+  name            = "pan-nsi-data-vpc"
+  subnetwork_name = "pan-nsi-data-subnet"
+  ip_cidr_range   = "10.0.1.0/24"
+  firewall_rules = {
+    allow-healthchecks = {
+      name = "pan-nsi-allow-hc"
+      source_ranges = [
+        "35.191.0.0/16",
+        "130.211.0.0/22",
+        "209.85.152.0/22",
+        "209.85.204.0/22",
+      ]
+      allowed_protocol = "tcp"
+      allowed_ports    = ["443"]
+      priority         = 900
+    }
+  }
+}
+
+
+consumer_vpcs = {
+  spoke-1 = {
+    name            = "pan-nsi-spoke1-vpc"
+    subnetwork_name = "pan-nsi-spoke1-subnet"
+    ip_cidr_range   = "192.168.1.0/24"
+    firewall_rules = {
+      allow-internal = {
+        name             = "pan-nsi-spoke1-allow-internal"
+        source_ranges    = ["192.168.0.0/16"]
+        allowed_protocol = "all"
+        allowed_ports    = []
+      }
+      allow-iap-ssh = {
+        name             = "pan-nsi-spoke1-allow-iap"
+        source_ranges    = ["35.235.240.0/20"]
+        allowed_protocol = "tcp"
+        allowed_ports    = ["22"]
+      }
+    }
+  }
+  spoke-2 = {
+    name            = "pan-nsi-spoke2-vpc"
+    subnetwork_name = "pan-nsi-spoke2-subnet"
+    ip_cidr_range   = "192.168.2.0/24"
+    firewall_rules = {
+      allow-internal = {
+        name             = "pan-nsi-spoke2-allow-internal"
+        source_ranges    = ["192.168.0.0/16"]
+        allowed_protocol = "all"
+        allowed_ports    = []
+      }
+      allow-iap-ssh = {
+        name             = "pan-nsi-spoke2-allow-iap"
+        source_ranges    = ["35.235.240.0/20"]
+        allowed_protocol = "tcp"
+        allowed_ports    = ["22"]
+      }
+    }
+  }
+}
+
+# These are applied to each consumer VPC. The nsi_intercept module automatically
+# sets action=apply_security_profile_group on all rules.
+firewall_policy_rules = [
+  {
+    priority    = 1000
+    direction   = "EGRESS"
+    description = "Intercept all egress for PAN-OS inspection"
+    match = {
+      dest_ip_ranges = ["0.0.0.0/0"]
+      layer4_configs = [{ ip_protocol = "all" }]
+    }
+  },
+  {
+    priority    = 1001
+    direction   = "INGRESS"
+    description = "Intercept all ingress for PAN-OS inspection"
+    match = {
+      src_ip_ranges  = ["0.0.0.0/0"]
+      layer4_configs = [{ ip_protocol = "all" }]
+    }
+  },
+]
+
+# Set enable_ncc = false to skip NCC and manage consumer VPC connectivity separately.
+enable_ncc   = true
+ncc_topology = "MESH"
+
+# Optional: Deploy small Debian VMs in each spoke for validating NSI interception.
+linux_vms = {
+  spoke1-vm = {
+    zone                    = "us-central1-a"
+    consumer_vpc_key        = "spoke-1"
+    machine_type            = "e2-micro"
+    disk_size_gb            = 20
+    metadata_startup_script = <<-EOT
+      #!/bin/bash
+      apt-get update -y
+      apt-get install -y nginx curl
+      echo "spoke-1-vm" > /var/www/html/index.html
+    EOT
+  }
+  spoke2-vm = {
+    zone                    = "us-central1-b"
+    consumer_vpc_key        = "spoke-2"
+    machine_type            = "e2-micro"
+    disk_size_gb            = 20
+    metadata_startup_script = <<-EOT
+      #!/bin/bash
+      apt-get update -y
+      apt-get install -y nginx curl
+      echo "spoke-2-vm" > /var/www/html/index.html
+    EOT
+  }
+}

--- a/examples/vmseries_nsi/main.tf
+++ b/examples/vmseries_nsi/main.tf
@@ -1,0 +1,189 @@
+
+module "iam_service_account" {
+  source = "../../modules/iam_service_account"
+
+  service_account_id = var.service_account.service_account_id
+  display_name       = "VM-Series NSI Service Account"
+  project_id         = var.project
+  roles              = var.service_account.roles
+}
+
+
+module "mgmt_vpc" {
+  source = "../../modules/vpc"
+
+  project_id = var.project
+  name       = var.mgmt_vpc.name
+  subnetworks = {
+    mgmt = {
+      name          = var.mgmt_vpc.subnetwork_name
+      ip_cidr_range = var.mgmt_vpc.ip_cidr_range
+      region        = var.region
+    }
+  }
+  firewall_rules = var.mgmt_vpc.firewall_rules
+}
+
+module "data_vpc" {
+  source = "../../modules/vpc"
+
+  project_id = var.project
+  name       = var.data_vpc.name
+  subnetworks = {
+    data = {
+      name          = var.data_vpc.subnetwork_name
+      ip_cidr_range = var.data_vpc.ip_cidr_range
+      region        = var.region
+    }
+  }
+  firewall_rules = var.data_vpc.firewall_rules
+}
+
+
+module "consumer_vpcs" {
+  for_each = var.consumer_vpcs
+  source   = "../../modules/vpc"
+
+  project_id = var.project
+  name       = each.value.name
+  subnetworks = {
+    default = {
+      name          = each.value.subnetwork_name
+      ip_cidr_range = each.value.ip_cidr_range
+      region        = var.region
+    }
+  }
+  firewall_rules = each.value.firewall_rules
+}
+
+
+module "vmseries" {
+  for_each = var.vmseries
+  source   = "../../modules/vmseries"
+
+  name                  = "${var.name_prefix}${each.key}"
+  zone                  = each.value.zone
+  project               = var.project
+  ssh_keys              = var.ssh_keys
+  vmseries_image        = var.vmseries_image
+  machine_type          = var.vmseries_common.machine_type
+  min_cpu_platform      = var.vmseries_common.min_cpu_platform
+  service_account       = module.iam_service_account.email
+  create_instance_group = true
+
+  bootstrap_options = merge(
+    var.vmseries_common.bootstrap_options,
+    each.value.bootstrap_options,
+    { plugin-op-commands = "geneve-inspect:enable" }
+  )
+
+  network_interfaces = [
+    {
+      subnetwork       = module.mgmt_vpc.subnetworks["mgmt"].self_link
+      create_public_ip = var.create_mgmt_public_ip
+    },
+    {
+      subnetwork       = module.data_vpc.subnetworks["data"].self_link
+      create_public_ip = false
+    },
+  ]
+}
+
+resource "google_compute_region_health_check" "geneve_hc" {
+  name    = "${var.name_prefix}geneve-hc"
+  project = var.project
+  region  = var.region
+
+  https_health_check {
+    port         = 443
+    request_path = "/unauth/php/health.php"
+  }
+}
+
+#
+module "geneve_ilb" {
+  for_each = var.vmseries
+  source   = "../../modules/lb_internal"
+
+  name    = "${var.name_prefix}geneve-ilb-${each.key}"
+  project = var.project
+  region  = var.region
+
+  subnetwork   = module.data_vpc.subnetworks["data"].self_link
+  network      = module.data_vpc.network.self_link
+  protocol     = "UDP"
+  ip_protocol  = "UDP"
+  ports        = ["6081"]
+  health_check = google_compute_region_health_check.geneve_hc.self_link
+
+  backends = { for k, v in module.vmseries : k => v.instance_group_self_link }
+}
+
+module "nsi" {
+  source = "../../modules/nsi_intercept"
+
+  project_id             = var.project
+  name_prefix            = var.name_prefix
+  producer_vpc_self_link = module.data_vpc.network.self_link
+
+  zonal_forwarding_rules = {
+    for fw_key, fw in var.vmseries : fw.zone => module.geneve_ilb[fw_key].forwarding_rule
+  }
+
+  consumer_vpcs = {
+    for k, v in module.consumer_vpcs : k => {
+      self_link = v.network.self_link
+    }
+  }
+
+  firewall_policy_rules = var.firewall_policy_rules
+}
+
+module "ncc" {
+  count  = var.enable_ncc ? 1 : 0
+  source = "../../modules/ncc_connectivity"
+
+  project_id  = var.project
+  name_prefix = var.name_prefix
+  topology    = var.ncc_topology
+
+  vpc_spokes = {
+    for k, v in module.consumer_vpcs : k => {
+      vpc_self_link = v.network.self_link
+    }
+  }
+}
+
+resource "google_compute_instance" "linux_vms" {
+  for_each = var.linux_vms
+
+  name         = "${var.name_prefix}${each.key}"
+  zone         = each.value.zone
+  project      = var.project
+  machine_type = each.value.machine_type
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-12"
+      size  = each.value.disk_size_gb
+    }
+  }
+
+  network_interface {
+    subnetwork = module.consumer_vpcs[each.value.consumer_vpc_key].subnetworks["default"].self_link
+  }
+
+  metadata_startup_script = each.value.metadata_startup_script
+
+  service_account {
+    email  = module.iam_service_account.email
+    scopes = ["cloud-platform"]
+  }
+
+  lifecycle {
+    precondition {
+      condition     = contains(keys(var.consumer_vpcs), each.value.consumer_vpc_key)
+      error_message = "linux_vms[\"${each.key}\"].consumer_vpc_key=\"${each.value.consumer_vpc_key}\" does not match any key in var.consumer_vpcs."
+    }
+  }
+}

--- a/examples/vmseries_nsi/main_test.go
+++ b/examples/vmseries_nsi/main_test.go
@@ -1,0 +1,11 @@
+package vmseries_nsi
+
+import (
+	"testing"
+
+	"github.com/PaloAltoNetworks/terraform-modules-swfw-tests-skeleton/pkg/testskeleton"
+)
+
+func TestValidate(t *testing.T) {
+	testskeleton.ValidateCode(t, nil)
+}

--- a/examples/vmseries_nsi/outputs.tf
+++ b/examples/vmseries_nsi/outputs.tf
@@ -1,0 +1,44 @@
+output "vmseries_private_ips" {
+  description = "Map of VM-Series instance key => map of NIC index => private IP address."
+  value       = { for k, v in module.vmseries : k => v.private_ips }
+}
+
+output "vmseries_public_ips" {
+  description = "Map of VM-Series instance key => map of NIC index => public IP address (null when not created)."
+  value       = { for k, v in module.vmseries : k => v.public_ips }
+}
+
+output "geneve_ilb_addresses" {
+  description = "Map of VM-Series instance key => internal IP address of the per-zone GENEVE ILB forwarding rule."
+  value       = { for k, v in module.geneve_ilb : k => v.address }
+}
+
+output "nsi_endpoint_group_id" {
+  description = "Full resource ID of the NSI intercept endpoint group."
+  value       = module.nsi.endpoint_group_id
+}
+
+output "nsi_deployment_group_id" {
+  description = "Full resource ID of the NSI intercept deployment group."
+  value       = module.nsi.deployment_group_id
+}
+
+output "nsi_security_profile_group_id" {
+  description = "Full resource ID of the NSI security profile group."
+  value       = module.nsi.security_profile_group_id
+}
+
+output "ncc_hub_id" {
+  description = "Full resource ID of the NCC hub (null when enable_ncc = false)."
+  value       = var.enable_ncc ? module.ncc[0].hub_id : null
+}
+
+output "ncc_spoke_names" {
+  description = "Map of consumer VPC key => NCC spoke resource name (empty when enable_ncc = false)."
+  value       = var.enable_ncc ? module.ncc[0].spoke_names : {}
+}
+
+output "linux_vm_ips" {
+  description = "Map of Linux VM key => internal IP address (populated only when linux_vms is configured)."
+  value       = { for k, v in google_compute_instance.linux_vms : k => v.network_interface[0].network_ip }
+}

--- a/examples/vmseries_nsi/variables.tf
+++ b/examples/vmseries_nsi/variables.tf
@@ -1,0 +1,228 @@
+variable "project" {
+  type        = string
+  description = "GCP project ID for all resources."
+}
+
+variable "region" {
+  type        = string
+  description = "GCP region for subnets, ILBs, and Cloud Router."
+}
+
+variable "name_prefix" {
+  type        = string
+  description = "Short prefix applied to every resource name (e.g. \"pan-nsi-\")."
+}
+
+
+variable "service_account" {
+  type = object({
+    service_account_id = string
+    roles              = list(string)
+  })
+  default = {
+    service_account_id = "sa-ngfw-vmseries"
+    roles = [
+      "roles/compute.networkViewer",
+      "roles/logging.logWriter",
+      "roles/monitoring.metricWriter",
+      "roles/monitoring.viewer",
+      "roles/stackdriver.accounts.viewer",
+      "roles/stackdriver.resourceMetadata.writer",
+    ]
+  }
+  description = "Service account configuration for the VM-Series instances."
+}
+
+
+variable "ssh_keys" {
+  type        = string
+  sensitive   = true
+  description = "SSH public key(s) for instance-level access (format: \"user:ssh-ed25519 AAAA... user@host\")."
+}
+
+variable "vmseries_image" {
+  type        = string
+  description = "Full VM-Series image name. Must be PAN-OS >= 11.2 for NSI GENEVE support (e.g. \"vmseries-flex-byol-1120\")."
+}
+
+variable "create_mgmt_public_ip" {
+  type        = bool
+  default     = false
+  description = "Assign a public IP to the mgmt NIC. Set true in lab environments for direct SSH/HTTPS access."
+}
+
+variable "vmseries_common" {
+  type = object({
+    machine_type     = optional(string, "n2-standard-8")
+    min_cpu_platform = optional(string, "Intel Cascade Lake")
+    bootstrap_options = optional(map(string), {
+      type                        = "dhcp-client"
+      dhcp-send-client-id         = "yes"
+      dhcp-accept-server-hostname = "yes"
+      dhcp-accept-server-domain   = "yes"
+      dns-primary                 = "169.254.169.254"
+      panorama-server             = ""
+    })
+  })
+  default     = {}
+  description = <<-EOT
+    Common settings shared across all VM-Series instances.
+    The bootstrap option `plugin-op-commands = "geneve-inspect:enable"` is always
+    merged in automatically — do not include it here as it would be overwritten.
+  EOT
+}
+
+variable "vmseries" {
+  type = map(object({
+    zone              = string
+    bootstrap_options = optional(map(string), {})
+  }))
+  description = <<-EOT
+    Map of VM-Series instance key => zone and per-instance bootstrap overrides.
+    Typically two entries (one per zone) for zone-redundant active-active deployment.
+    The module forces `plugin-op-commands = "geneve-inspect:enable"` in the merged
+    bootstrap_options regardless of what is set here.
+    Each entry must use a unique zone — NSI requires one ILB forwarding rule per zone,
+    and the example maps zone => forwarding rule one-to-one.
+  EOT
+
+  validation {
+    condition     = length(values(var.vmseries)[*].zone) == length(distinct(values(var.vmseries)[*].zone))
+    error_message = "Every vmseries entry must be in a unique zone."
+  }
+}
+
+
+variable "mgmt_vpc" {
+  type = object({
+    name            = string
+    subnetwork_name = string
+    ip_cidr_range   = string
+    firewall_rules = optional(map(object({
+      name             = string
+      source_ranges    = optional(list(string))
+      source_tags      = optional(list(string))
+      allowed_protocol = string
+      allowed_ports    = optional(list(string), [])
+      priority         = optional(number, 1000)
+    })), {})
+  })
+  description = "Management VPC for VM-Series NIC0. Kept separate from data_vpc so GCP health checks target NIC1."
+}
+
+variable "data_vpc" {
+  type = object({
+    name            = string
+    subnetwork_name = string
+    ip_cidr_range   = string
+    firewall_rules = optional(map(object({
+      name             = string
+      source_ranges    = optional(list(string))
+      source_tags      = optional(list(string))
+      allowed_protocol = string
+      allowed_ports    = optional(list(string), [])
+      priority         = optional(number, 1000)
+    })), {})
+  })
+  description = "Data/GENEVE VPC for VM-Series NIC1. The GENEVE ILB and NSI intercept deployment group live here."
+}
+
+
+variable "consumer_vpcs" {
+  type = map(object({
+    name            = string
+    subnetwork_name = string
+    ip_cidr_range   = string
+    firewall_rules = optional(map(object({
+      name             = string
+      source_ranges    = optional(list(string))
+      source_tags      = optional(list(string))
+      allowed_protocol = string
+      allowed_ports    = optional(list(string), [])
+      priority         = optional(number, 1000)
+    })), {})
+    firewall_policy_rules = optional(list(object({
+      priority    = number
+      direction   = string
+      description = optional(string, "")
+      match = object({
+        src_ip_ranges  = optional(list(string), [])
+        dest_ip_ranges = optional(list(string), [])
+        layer4_configs = list(object({
+          ip_protocol = string
+          ports       = optional(list(string), [])
+        }))
+      })
+    })), null)
+  }))
+  description = "Map of consumer/spoke VPC key => VPC and subnet configuration. Each entry gets one NCC spoke and one NSI endpoint-group association."
+}
+
+
+variable "firewall_policy_rules" {
+  type = list(object({
+    priority    = number
+    direction   = string
+    description = optional(string, "")
+    match = object({
+      src_ip_ranges  = optional(list(string), [])
+      dest_ip_ranges = optional(list(string), [])
+      layer4_configs = list(object({
+        ip_protocol = string
+        ports       = optional(list(string), [])
+      }))
+    })
+  }))
+  default = [
+    {
+      priority    = 1000
+      direction   = "EGRESS"
+      description = "Intercept all egress for PAN-OS inspection"
+      match = {
+        dest_ip_ranges = ["0.0.0.0/0"]
+        layer4_configs = [{ ip_protocol = "all" }]
+      }
+    },
+    {
+      priority    = 1001
+      direction   = "INGRESS"
+      description = "Intercept all ingress for PAN-OS inspection"
+      match = {
+        src_ip_ranges  = ["0.0.0.0/0"]
+        layer4_configs = [{ ip_protocol = "all" }]
+      }
+    },
+  ]
+  description = "Firewall policy rules applied to each consumer VPC. The nsi_intercept module sets action=apply_security_profile_group automatically."
+}
+
+
+variable "enable_ncc" {
+  type        = bool
+  default     = true
+  description = "Deploy a Network Connectivity Center hub and attach each consumer VPC as a spoke. When true, all consumer VPCs gain transitive (MESH) routing through the hub, which NSI then inspects. Set false to skip NCC entirely and manage connectivity separately."
+}
+
+variable "ncc_topology" {
+  type        = string
+  default     = "MESH"
+  description = "NCC hub preset topology. MESH allows all spokes to reach each other; STAR requires designating center spokes."
+
+  validation {
+    condition     = contains(["MESH", "STAR"], var.ncc_topology)
+    error_message = "ncc_topology must be MESH or STAR."
+  }
+}
+
+
+variable "linux_vms" {
+  type = map(object({
+    zone                    = string
+    consumer_vpc_key        = string
+    machine_type            = optional(string, "e2-micro")
+    disk_size_gb            = optional(number, 20)
+    metadata_startup_script = optional(string, null)
+  }))
+  default     = {}
+  description = "Optional Linux test VMs to deploy in consumer VPCs for validating NSI traffic interception end-to-end."
+}

--- a/examples/vmseries_nsi/versions.tf
+++ b/examples/vmseries_nsi/versions.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_version = ">= 1.3, < 2.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.15"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 6.15"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project
+  region  = var.region
+}
+
+provider "google-beta" {
+  project = var.project
+  region  = var.region
+}

--- a/modules/lb_internal/README.md
+++ b/modules/lb_internal/README.md
@@ -56,6 +56,7 @@ Name | Type | Description
 [`network`](#network) | `any` | .
 [`ports`](#ports) | `list` | Which port numbers are forwarded to the backends (up to 5 ports).
 [`project`](#project) | `string` | The project to deploy to.
+[`protocol`](#protocol) | `string` | The protocol for the backend service.
 [`region`](#region) | `string` | Region to create ILB in.
 [`session_affinity`](#session_affinity) | `string` | Controls distribution of new connections (or fragmented UDP packets) from clients to the backends, can influence available connection tracking configurations.
 [`timeout_sec`](#timeout_sec) | `number` | (Optional) How many seconds to wait for the backend before dropping the connection.
@@ -261,6 +262,16 @@ The project to deploy to. If unset the default provider project is used.
 Type: string
 
 Default value: `&{}`
+
+<sup>[back to list](#modules-optional-inputs)</sup>
+
+#### protocol
+
+The protocol for the backend service. Must match ip_protocol when using UDP. Valid values are TCP and UDP. Defaults to TCP for backwards compatibility.
+
+Type: string
+
+Default value: `TCP`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
 

--- a/modules/lb_internal/main.tf
+++ b/modules/lb_internal/main.tf
@@ -15,6 +15,7 @@ resource "google_compute_region_backend_service" "this" {
   project = var.project
   region  = var.region
 
+  protocol                        = var.protocol
   health_checks                   = [var.health_check != null ? var.health_check : google_compute_health_check.this.self_link]
   session_affinity                = var.session_affinity
   timeout_sec                     = var.timeout_sec

--- a/modules/lb_internal/variables.tf
+++ b/modules/lb_internal/variables.tf
@@ -64,6 +64,12 @@ variable "ip_protocol" {
   type        = string
 }
 
+variable "protocol" {
+  description = "The protocol for the backend service. Must match ip_protocol when using UDP. Valid values are TCP and UDP. Defaults to TCP for backwards compatibility."
+  default     = "TCP"
+  type        = string
+}
+
 variable "all_ports" {
   description = "Forward all ports of the ip_protocol from the frontend to the backends. Needs to be null if `ports` are provided."
   default     = null

--- a/modules/ncc_connectivity/.header.md
+++ b/modules/ncc_connectivity/.header.md
@@ -1,0 +1,22 @@
+# Palo Alto Networks Network Connectivity Center (NCC) module
+
+This module creates a Google Cloud **Network Connectivity Center (NCC)** hub and attaches VPC spokes to it, providing transitive hub-and-spoke connectivity between workload VPCs without requiring explicit VPC peerings between each pair.
+
+## Use with NSI
+
+When combined with the `nsi_intercept` module, NCC provides the data path that NSI inspects. The NCC hub routes traffic between consumer (spoke) VPCs; the NSI firewall policies steer that inter-spoke traffic through the VM-Series fleet for deep-packet inspection. This pattern enables centralized security across all spoke-to-spoke and spoke-to-internet traffic flows.
+
+## Topology
+
+The `topology` variable controls how spokes exchange routes:
+
+- **`MESH`** (default) — all spokes can reach all other spokes through the hub. Traffic between any two consumer VPCs is routed via NCC and can be intercepted by NSI.
+- **`STAR`** — designate some spokes as "center" and others as "edge"; only center↔edge traffic is transitive. Not used by default in this module.
+
+## Excluding ranges from export
+
+`vpc_spokes[<key>].exclude_export_ranges` takes a list of CIDR prefixes that should **not** be advertised from that spoke to the hub. Use this to prevent hub-to-spoke route loops or to suppress private service access ranges (e.g., `199.36.153.4/30`).
+
+## Bringing an existing hub
+
+Set `create_hub = false` and supply `existing_hub_id` (format: `projects/<project>/locations/global/hubs/<name>`) to attach spokes to a pre-existing hub. This is useful in multi-tenant deployments where the hub is managed centrally and spokes are added per workload team.

--- a/modules/ncc_connectivity/README.md
+++ b/modules/ncc_connectivity/README.md
@@ -1,0 +1,142 @@
+# Palo Alto Networks Network Connectivity Center (NCC) module
+
+This module creates a Google Cloud **Network Connectivity Center (NCC)** hub and attaches VPC spokes to it, providing transitive hub-and-spoke connectivity between workload VPCs without requiring explicit VPC peerings between each pair.
+
+## Use with NSI
+
+When combined with the `nsi_intercept` module, NCC provides the data path that NSI inspects. The NCC hub routes traffic between consumer (spoke) VPCs; the NSI firewall policies steer that inter-spoke traffic through the VM-Series fleet for deep-packet inspection. This pattern enables centralized security across all spoke-to-spoke and spoke-to-internet traffic flows.
+
+## Topology
+
+The `topology` variable controls how spokes exchange routes:
+
+- **`MESH`** (default) — all spokes can reach all other spokes through the hub. Traffic between any two consumer VPCs is routed via NCC and can be intercepted by NSI.
+- **`STAR`** — designate some spokes as "center" and others as "edge"; only center↔edge traffic is transitive. Not used by default in this module.
+
+## Excluding ranges from export
+
+`vpc_spokes[<key>].exclude_export_ranges` takes a list of CIDR prefixes that should **not** be advertised from that spoke to the hub. Use this to prevent hub-to-spoke route loops or to suppress private service access ranges (e.g., `199.36.153.4/30`).
+
+## Bringing an existing hub
+
+Set `create_hub = false` and supply `existing_hub_id` (format: `projects/<project>/locations/global/hubs/<name>`) to attach spokes to a pre-existing hub. This is useful in multi-tenant deployments where the hub is managed centrally and spokes are added per workload team.
+
+## Reference
+
+### Requirements
+
+- `terraform`, version: >= 1.3, < 2.0
+- `google`, version: >= 5.0
+
+### Providers
+
+- `google`, version: >= 5.0
+
+
+
+### Resources
+
+- `network_connectivity_hub` (managed)
+- `network_connectivity_spoke` (managed)
+
+### Required Inputs
+
+Name | Type | Description
+--- | --- | ---
+[`name_prefix`](#name_prefix) | `string` | Short prefix applied to every resource name.
+[`project_id`](#project_id) | `string` | GCP project ID where the NCC hub will be created.
+[`vpc_spokes`](#vpc_spokes) | `map` | Map of spoke-key => { vpc_self_link, exclude_export_ranges }.
+
+### Optional Inputs
+
+Name | Type | Description
+--- | --- | ---
+[`create_hub`](#create_hub) | `bool` | Create the NCC hub.
+[`existing_hub_id`](#existing_hub_id) | `string` | Full resource ID of an existing NCC hub (projects/.
+[`hub_name`](#hub_name) | `string` | Name for the NCC hub.
+[`topology`](#topology) | `string` | NCC hub preset topology: MESH (all spokes can reach all other spokes) or STAR.
+
+### Outputs
+
+Name |  Description
+--- | ---
+`hub_id` | Full resource ID of the NCC hub (created or pre-existing).
+`hub_name` | Name of the NCC hub.
+`spoke_ids` | Map of spoke-key => spoke full resource ID.
+`spoke_names` | Map of spoke-key => spoke resource name.
+
+### Required Inputs details
+
+#### name_prefix
+
+Short prefix applied to every resource name.
+
+Type: string
+
+<sup>[back to list](#modules-required-inputs)</sup>
+
+#### project_id
+
+GCP project ID where the NCC hub will be created.
+
+Type: string
+
+<sup>[back to list](#modules-required-inputs)</sup>
+
+#### vpc_spokes
+
+Map of spoke-key => { vpc_self_link, exclude_export_ranges }. One VPC spoke per consumer VPC.
+
+Type: 
+
+```hcl
+map(object({
+    vpc_self_link         = string
+    exclude_export_ranges = optional(list(string), [])
+  }))
+```
+
+
+<sup>[back to list](#modules-required-inputs)</sup>
+
+### Optional Inputs details
+
+#### create_hub
+
+Create the NCC hub. Set false to attach spokes to an existing hub (supply existing_hub_id).
+
+Type: bool
+
+Default value: `true`
+
+<sup>[back to list](#modules-optional-inputs)</sup>
+
+#### existing_hub_id
+
+Full resource ID of an existing NCC hub (projects/.../locations/global/hubs/...). Required when create_hub = false.
+
+Type: string
+
+Default value: `&{}`
+
+<sup>[back to list](#modules-optional-inputs)</sup>
+
+#### hub_name
+
+Name for the NCC hub. Defaults to "<name_prefix>ncc-hub" when null.
+
+Type: string
+
+Default value: `&{}`
+
+<sup>[back to list](#modules-optional-inputs)</sup>
+
+#### topology
+
+NCC hub preset topology: MESH (all spokes can reach all other spokes) or STAR.
+
+Type: string
+
+Default value: `MESH`
+
+<sup>[back to list](#modules-optional-inputs)</sup>

--- a/modules/ncc_connectivity/main.tf
+++ b/modules/ncc_connectivity/main.tf
@@ -1,0 +1,35 @@
+locals {
+  hub_name = coalesce(var.hub_name, "${var.name_prefix}ncc-hub")
+  hub_id   = var.create_hub ? google_network_connectivity_hub.this[0].id : var.existing_hub_id
+}
+
+resource "google_network_connectivity_hub" "this" {
+  count   = var.create_hub ? 1 : 0
+  name    = local.hub_name
+  project = var.project_id
+
+  # policy_mode = "PRESET" is required for preset_topology to be accepted.
+  policy_mode     = "PRESET"
+  preset_topology = var.topology
+}
+
+resource "google_network_connectivity_spoke" "this" {
+  for_each = var.vpc_spokes
+
+  name     = "${var.name_prefix}spoke-${each.key}"
+  location = "global"
+  project  = var.project_id
+  hub      = local.hub_id
+
+  linked_vpc_network {
+    uri                   = each.value.vpc_self_link
+    exclude_export_ranges = each.value.exclude_export_ranges
+  }
+
+  lifecycle {
+    precondition {
+      condition     = var.create_hub || var.existing_hub_id != null
+      error_message = "existing_hub_id must be set when create_hub = false."
+    }
+  }
+}

--- a/modules/ncc_connectivity/main_test.go
+++ b/modules/ncc_connectivity/main_test.go
@@ -1,0 +1,11 @@
+package ncc_connectivity
+
+import (
+	"testing"
+
+	"github.com/PaloAltoNetworks/terraform-modules-swfw-tests-skeleton/pkg/testskeleton"
+)
+
+func TestValidate(t *testing.T) {
+	testskeleton.ValidateCode(t, nil)
+}

--- a/modules/ncc_connectivity/outputs.tf
+++ b/modules/ncc_connectivity/outputs.tf
@@ -1,0 +1,19 @@
+output "hub_id" {
+  description = "Full resource ID of the NCC hub (created or pre-existing)."
+  value       = local.hub_id
+}
+
+output "hub_name" {
+  description = "Name of the NCC hub."
+  value       = local.hub_name
+}
+
+output "spoke_names" {
+  description = "Map of spoke-key => spoke resource name."
+  value       = { for k, v in google_network_connectivity_spoke.this : k => v.name }
+}
+
+output "spoke_ids" {
+  description = "Map of spoke-key => spoke full resource ID."
+  value       = { for k, v in google_network_connectivity_spoke.this : k => v.id }
+}

--- a/modules/ncc_connectivity/variables.tf
+++ b/modules/ncc_connectivity/variables.tf
@@ -1,0 +1,46 @@
+variable "project_id" {
+  type        = string
+  description = "GCP project ID where the NCC hub will be created."
+}
+
+variable "name_prefix" {
+  type        = string
+  description = "Short prefix applied to every resource name."
+}
+
+variable "create_hub" {
+  type        = bool
+  default     = true
+  description = "Create the NCC hub. Set false to attach spokes to an existing hub (supply existing_hub_id)."
+}
+
+variable "hub_name" {
+  type        = string
+  default     = null
+  description = "Name for the NCC hub. Defaults to \"<name_prefix>ncc-hub\" when null."
+}
+
+variable "existing_hub_id" {
+  type        = string
+  default     = null
+  description = "Full resource ID of an existing NCC hub (projects/.../locations/global/hubs/...). Required when create_hub = false."
+}
+
+variable "topology" {
+  type        = string
+  default     = "MESH"
+  description = "NCC hub preset topology: MESH (all spokes can reach all other spokes) or STAR."
+
+  validation {
+    condition     = contains(["MESH", "STAR"], var.topology)
+    error_message = "topology must be MESH or STAR."
+  }
+}
+
+variable "vpc_spokes" {
+  type = map(object({
+    vpc_self_link         = string
+    exclude_export_ranges = optional(list(string), [])
+  }))
+  description = "Map of spoke-key => { vpc_self_link, exclude_export_ranges }. One VPC spoke per consumer VPC."
+}

--- a/modules/ncc_connectivity/versions.tf
+++ b/modules/ncc_connectivity/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.3, < 2.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/modules/nsi_intercept/.header.md
+++ b/modules/nsi_intercept/.header.md
@@ -1,0 +1,34 @@
+# Palo Alto Networks VM-Series Network Security Integration (NSI) module
+
+This module configures Google Cloud **Network Security Integration (NSI)** — a transparent, GENEVE-based traffic-interception mechanism that steers consumer VPC traffic through a producer-side VM-Series fleet without changing routes or adding peerings.
+
+## Architecture overview
+
+NSI uses a two-sided model:
+
+**Producer side** (inside the security/producer VPC):
+
+- One `intercept_deployment` per firewall zone — references the VM-Series Internal Passthrough NLB forwarding rule that listens on UDP/6081 (GENEVE port). Because `intercept_deployment` is zone-scoped, a unique forwarding rule per zone is required even when all zones share the same backend service.
+- A single global `intercept_deployment_group` that aggregates all zone-level deployments for a producer VPC.
+- A single global `intercept_endpoint_group` — the logical handle that consumer associations reference.
+- An optional `security_profile` + `security_profile_group` — the policy object that tells GCP which endpoint group to redirect matched traffic to. Set `create_security_profile = false` and supply `existing_security_profile_group_id` to reuse an existing profile across multiple producer VPCs.
+
+**Consumer side** (inside each workload/spoke VPC):
+
+- One `intercept_endpoint_group_association` per consumer VPC — activates NSI interception. **Allow 5–15 minutes per VPC for this resource to reach `ACTIVE` state on first apply.**
+- One global `network_firewall_policy` per consumer VPC with rules that have `action = apply_security_profile_group` — this is what actually steers the matched flows into NSI.
+- A `network_firewall_policy_association` that attaches the policy to the consumer VPC.
+
+## VM-Series requirements
+
+- PAN-OS **≥ 11.2** for GENEVE decapsulation support.
+- Bootstrap option `plugin-op-commands = "geneve-inspect:enable"` must be present in the VM-Series bootstrap metadata.
+- In PAN-OS, configure a loopback interface for each ILB forwarding-rule IP with an HTTPS management profile that allows the GCP health-check source ranges:
+  - `35.191.0.0/16`
+  - `130.211.0.0/22`
+  - `209.85.152.0/22`
+  - `209.85.204.0/22`
+
+## Cross-project consumer VPCs
+
+When a consumer VPC lives in a different project than `var.project_id`, set `consumer_vpcs[<key>].project_id` to that VPC's project. GCP requires the `intercept_endpoint_group_association` and the `network_firewall_policy` to reside in the same project as the consumer VPC network.

--- a/modules/nsi_intercept/README.md
+++ b/modules/nsi_intercept/README.md
@@ -1,0 +1,207 @@
+# Palo Alto Networks VM-Series Network Security Integration (NSI) module
+
+This module configures Google Cloud **Network Security Integration (NSI)** — a transparent, GENEVE-based traffic-interception mechanism that steers consumer VPC traffic through a producer-side VM-Series fleet without changing routes or adding peerings.
+
+## Architecture overview
+
+NSI uses a two-sided model:
+
+**Producer side** (inside the security/producer VPC):
+
+- One `intercept_deployment` per firewall zone — references the VM-Series Internal Passthrough NLB forwarding rule that listens on UDP/6081 (GENEVE port). Because `intercept_deployment` is zone-scoped, a unique forwarding rule per zone is required even when all zones share the same backend service.
+- A single global `intercept_deployment_group` that aggregates all zone-level deployments for a producer VPC.
+- A single global `intercept_endpoint_group` — the logical handle that consumer associations reference.
+- An optional `security_profile` + `security_profile_group` — the policy object that tells GCP which endpoint group to redirect matched traffic to. Set `create_security_profile = false` and supply `existing_security_profile_group_id` to reuse an existing profile across multiple producer VPCs.
+
+**Consumer side** (inside each workload/spoke VPC):
+
+- One `intercept_endpoint_group_association` per consumer VPC — activates NSI interception. **Allow 5–15 minutes per VPC for this resource to reach `ACTIVE` state on first apply.**
+- One global `network_firewall_policy` per consumer VPC with rules that have `action = apply_security_profile_group` — this is what actually steers the matched flows into NSI.
+- A `network_firewall_policy_association` that attaches the policy to the consumer VPC.
+
+## VM-Series requirements
+
+- PAN-OS **≥ 11.2** for GENEVE decapsulation support.
+- Bootstrap option `plugin-op-commands = "geneve-inspect:enable"` must be present in the VM-Series bootstrap metadata.
+- In PAN-OS, configure a loopback interface for each ILB forwarding-rule IP with an HTTPS management profile that allows the GCP health-check source ranges:
+  - `35.191.0.0/16`
+  - `130.211.0.0/22`
+  - `209.85.152.0/22`
+  - `209.85.204.0/22`
+
+## Cross-project consumer VPCs
+
+When a consumer VPC lives in a different project than `var.project_id`, set `consumer_vpcs[<key>].project_id` to that VPC's project. GCP requires the `intercept_endpoint_group_association` and the `network_firewall_policy` to reside in the same project as the consumer VPC network.
+
+## Reference
+
+### Requirements
+
+- `terraform`, version: >= 1.3, < 2.0
+- `google`, version: >= 6.15
+
+### Providers
+
+- `google`, version: >= 6.15
+
+
+
+### Resources
+
+- `compute_network_firewall_policy` (managed)
+- `compute_network_firewall_policy_association` (managed)
+- `compute_network_firewall_policy_rule` (managed)
+- `network_security_intercept_deployment` (managed)
+- `network_security_intercept_deployment_group` (managed)
+- `network_security_intercept_endpoint_group` (managed)
+- `network_security_intercept_endpoint_group_association` (managed)
+- `network_security_security_profile` (managed)
+- `network_security_security_profile_group` (managed)
+
+### Required Inputs
+
+Name | Type | Description
+--- | --- | ---
+[`consumer_vpcs`](#consumer_vpcs) | `map` | Consumer VPCs to protect.
+[`name_prefix`](#name_prefix) | `string` | Short prefix applied to every resource name.
+[`producer_vpc_self_link`](#producer_vpc_self_link) | `string` | Self-link of the producer/security VPC — used as the intercept deployment group network.
+[`project_id`](#project_id) | `string` | GCP project ID where NSI resources will be created.
+[`zonal_forwarding_rules`](#zonal_forwarding_rules) | `map` | Map of zone => ILB forwarding-rule self-link.
+
+### Optional Inputs
+
+Name | Type | Description
+--- | --- | ---
+[`create_security_profile`](#create_security_profile) | `bool` | Create the security_profile and security_profile_group.
+[`existing_security_profile_group_id`](#existing_security_profile_group_id) | `string` | Full ID of an existing security_profile_group.
+[`firewall_policy_rules`](#firewall_policy_rules) | `list` | Rules applied to each consumer VPC's global network firewall policy.
+
+### Outputs
+
+Name |  Description
+--- | ---
+`deployment_group_id` | Full resource ID of the intercept deployment group.
+`endpoint_group_association_ids` | Map of consumer-vpc-key => endpoint_group_association resource ID.
+`endpoint_group_id` | Full resource ID of the intercept endpoint group.
+`intercept_deployment_ids` | Map of zone => zonal intercept_deployment resource ID.
+`security_profile_group_id` | Full resource ID of the security_profile_group. Use to add additional firewall policy rules outside Terraform.
+
+### Required Inputs details
+
+#### consumer_vpcs
+
+Consumer VPCs to protect. Map of vpc-key => { self_link, project_id, firewall_policy_rules }.
+project_id must be set when the consumer VPC is in a different project than
+var.project_id — GCP requires the intercept_endpoint_group_association to be
+created in the same project as the consumer VPC network.
+firewall_policy_rules overrides the global var.firewall_policy_rules for this specific VPC.
+
+
+Type: 
+
+```hcl
+map(object({
+    self_link  = string
+    project_id = optional(string, null)
+    firewall_policy_rules = optional(list(object({
+      priority    = number
+      direction   = string
+      description = optional(string, "")
+      match = object({
+        src_ip_ranges  = optional(list(string), [])
+        dest_ip_ranges = optional(list(string), [])
+        layer4_configs = list(object({
+          ip_protocol = string
+          ports       = optional(list(string), [])
+        }))
+      })
+    })), null)
+  }))
+```
+
+
+<sup>[back to list](#modules-required-inputs)</sup>
+
+#### name_prefix
+
+Short prefix applied to every resource name.
+
+Type: string
+
+<sup>[back to list](#modules-required-inputs)</sup>
+
+#### producer_vpc_self_link
+
+Self-link of the producer/security VPC — used as the intercept deployment group network.
+
+Type: string
+
+<sup>[back to list](#modules-required-inputs)</sup>
+
+#### project_id
+
+GCP project ID where NSI resources will be created.
+
+Type: string
+
+<sup>[back to list](#modules-required-inputs)</sup>
+
+#### zonal_forwarding_rules
+
+Map of zone => ILB forwarding-rule self-link. google_network_security_intercept_deployment is zone-level
+(not regional), so one entry per FW zone is required. Multiple zones in the same region share the same
+regional ILB forwarding rule.
+
+
+Type: map(string)
+
+<sup>[back to list](#modules-required-inputs)</sup>
+
+### Optional Inputs details
+
+#### create_security_profile
+
+Create the security_profile and security_profile_group. Set false to reuse an existing profile group.
+
+Type: bool
+
+Default value: `true`
+
+<sup>[back to list](#modules-optional-inputs)</sup>
+
+#### existing_security_profile_group_id
+
+Full ID of an existing security_profile_group. Required when create_security_profile = false.
+
+Type: string
+
+Default value: `&{}`
+
+<sup>[back to list](#modules-optional-inputs)</sup>
+
+#### firewall_policy_rules
+
+Rules applied to each consumer VPC's global network firewall policy. The module automatically sets action=apply_security_profile_group.
+
+Type: 
+
+```hcl
+list(object({
+    priority    = number
+    direction   = string
+    description = optional(string, "")
+    match = object({
+      src_ip_ranges  = optional(list(string), [])
+      dest_ip_ranges = optional(list(string), [])
+      layer4_configs = list(object({
+        ip_protocol = string
+        ports       = optional(list(string), [])
+      }))
+    })
+  }))
+```
+
+
+Default value: `[map[description:Intercept all egress for PAN-OS inspection direction:EGRESS match:map[dest_ip_ranges:[0.0.0.0/0] layer4_configs:[map[ip_protocol:all]] src_ip_ranges:[]] priority:1000]]`
+
+<sup>[back to list](#modules-optional-inputs)</sup>

--- a/modules/nsi_intercept/main.tf
+++ b/modules/nsi_intercept/main.tf
@@ -1,0 +1,125 @@
+locals {
+  security_profile_group_id = var.create_security_profile ? google_network_security_security_profile_group.this[0].id : var.existing_security_profile_group_id
+
+  firewall_policy_rule_pairs = {
+    for pair in flatten([
+      for vpc_key, vpc in var.consumer_vpcs : [
+        for idx, rule in coalesce(vpc.firewall_policy_rules, var.firewall_policy_rules) : {
+          key     = "${vpc_key}--${idx}"
+          vpc_key = vpc_key
+          rule    = rule
+        }
+      ]
+    ]) : pair.key => pair
+  }
+}
+
+
+resource "google_network_security_intercept_deployment_group" "this" {
+  intercept_deployment_group_id = "${var.name_prefix}intercept-dgrp"
+  location                      = "global"
+  network                       = var.producer_vpc_self_link
+
+  lifecycle {
+    precondition {
+      condition     = var.create_security_profile || var.existing_security_profile_group_id != null
+      error_message = "existing_security_profile_group_id must be set when create_security_profile = false."
+    }
+  }
+}
+
+resource "google_network_security_intercept_deployment" "this" {
+  for_each = var.zonal_forwarding_rules
+
+  intercept_deployment_id    = "${var.name_prefix}intercept-${replace(each.key, "/", "-")}"
+  location                   = each.key
+  forwarding_rule            = each.value
+  intercept_deployment_group = google_network_security_intercept_deployment_group.this.id
+}
+
+resource "google_network_security_intercept_endpoint_group" "this" {
+  intercept_endpoint_group_id = "${var.name_prefix}intercept-egrp"
+  location                    = "global"
+  intercept_deployment_group  = google_network_security_intercept_deployment_group.this.id
+}
+
+
+resource "google_network_security_security_profile" "this" {
+  count = var.create_security_profile ? 1 : 0
+
+  name     = "${var.name_prefix}intercept-prof"
+  parent   = "projects/${var.project_id}"
+  location = "global"
+  type     = "CUSTOM_INTERCEPT"
+
+  custom_intercept_profile {
+    intercept_endpoint_group = google_network_security_intercept_endpoint_group.this.id
+  }
+}
+
+resource "google_network_security_security_profile_group" "this" {
+  count = var.create_security_profile ? 1 : 0
+
+  name                     = "${var.name_prefix}intercept-pgrp"
+  parent                   = "projects/${var.project_id}"
+  location                 = "global"
+  custom_intercept_profile = google_network_security_security_profile.this[0].id
+}
+
+
+resource "google_network_security_intercept_endpoint_group_association" "this" {
+  for_each = var.consumer_vpcs
+
+  # GCP requires the association to be in the same project as the consumer VPC network.
+  project = coalesce(each.value.project_id, var.project_id)
+
+  intercept_endpoint_group_association_id = "${var.name_prefix}assoc-${each.key}"
+  location                                = "global"
+  intercept_endpoint_group                = google_network_security_intercept_endpoint_group.this.id
+  network                                 = each.value.self_link
+
+  timeouts {
+    create = "30m"
+    delete = "30m"
+  }
+}
+
+resource "google_compute_network_firewall_policy" "this" {
+  for_each    = var.consumer_vpcs
+  name        = "${var.name_prefix}fwpol-${each.key}"
+  project     = coalesce(each.value.project_id, var.project_id)
+  description = "NSI intercept policy for ${each.key}"
+}
+
+resource "google_compute_network_firewall_policy_rule" "this" {
+  for_each        = local.firewall_policy_rule_pairs
+  firewall_policy = google_compute_network_firewall_policy.this[each.value.vpc_key].name
+  project         = coalesce(var.consumer_vpcs[each.value.vpc_key].project_id, var.project_id)
+  priority        = each.value.rule.priority
+  direction       = each.value.rule.direction
+  action          = "apply_security_profile_group"
+  description     = each.value.rule.description
+
+  security_profile_group = local.security_profile_group_id
+
+  match {
+    src_ip_ranges  = each.value.rule.match.src_ip_ranges
+    dest_ip_ranges = each.value.rule.match.dest_ip_ranges
+
+    dynamic "layer4_configs" {
+      for_each = each.value.rule.match.layer4_configs
+      content {
+        ip_protocol = layer4_configs.value.ip_protocol
+        ports       = layer4_configs.value.ports
+      }
+    }
+  }
+}
+
+resource "google_compute_network_firewall_policy_association" "this" {
+  for_each          = var.consumer_vpcs
+  name              = "${var.name_prefix}fwpol-assoc-${each.key}"
+  project           = coalesce(each.value.project_id, var.project_id)
+  attachment_target = each.value.self_link
+  firewall_policy   = google_compute_network_firewall_policy.this[each.key].id
+}

--- a/modules/nsi_intercept/main_test.go
+++ b/modules/nsi_intercept/main_test.go
@@ -1,0 +1,11 @@
+package nsi_intercept
+
+import (
+	"testing"
+
+	"github.com/PaloAltoNetworks/terraform-modules-swfw-tests-skeleton/pkg/testskeleton"
+)
+
+func TestValidate(t *testing.T) {
+	testskeleton.ValidateCode(t, nil)
+}

--- a/modules/nsi_intercept/outputs.tf
+++ b/modules/nsi_intercept/outputs.tf
@@ -1,0 +1,24 @@
+output "security_profile_group_id" {
+  description = "Full resource ID of the security_profile_group. Use to add additional firewall policy rules outside Terraform."
+  value       = local.security_profile_group_id
+}
+
+output "endpoint_group_id" {
+  description = "Full resource ID of the intercept endpoint group."
+  value       = google_network_security_intercept_endpoint_group.this.id
+}
+
+output "deployment_group_id" {
+  description = "Full resource ID of the intercept deployment group."
+  value       = google_network_security_intercept_deployment_group.this.id
+}
+
+output "endpoint_group_association_ids" {
+  description = "Map of consumer-vpc-key => endpoint_group_association resource ID."
+  value       = { for k, v in google_network_security_intercept_endpoint_group_association.this : k => v.id }
+}
+
+output "intercept_deployment_ids" {
+  description = "Map of zone => zonal intercept_deployment resource ID."
+  value       = { for k, v in google_network_security_intercept_deployment.this : k => v.id }
+}

--- a/modules/nsi_intercept/variables.tf
+++ b/modules/nsi_intercept/variables.tf
@@ -1,0 +1,96 @@
+variable "project_id" {
+  type        = string
+  description = "GCP project ID where NSI resources will be created."
+}
+
+variable "name_prefix" {
+  type        = string
+  description = "Short prefix applied to every resource name."
+}
+
+variable "producer_vpc_self_link" {
+  type        = string
+  description = "Self-link of the producer/security VPC — used as the intercept deployment group network."
+}
+
+variable "zonal_forwarding_rules" {
+  type        = map(string)
+  description = <<-EOT
+    Map of zone => ILB forwarding-rule self-link. google_network_security_intercept_deployment is zone-level
+    (not regional), so one entry per FW zone is required. Multiple zones in the same region share the same
+    regional ILB forwarding rule.
+  EOT
+}
+
+variable "consumer_vpcs" {
+  type = map(object({
+    self_link  = string
+    project_id = optional(string, null)
+    firewall_policy_rules = optional(list(object({
+      priority    = number
+      direction   = string
+      description = optional(string, "")
+      match = object({
+        src_ip_ranges  = optional(list(string), [])
+        dest_ip_ranges = optional(list(string), [])
+        layer4_configs = list(object({
+          ip_protocol = string
+          ports       = optional(list(string), [])
+        }))
+      })
+    })), null)
+  }))
+  description = <<-EOT
+    Consumer VPCs to protect. Map of vpc-key => { self_link, project_id, firewall_policy_rules }.
+    project_id must be set when the consumer VPC is in a different project than
+    var.project_id — GCP requires the intercept_endpoint_group_association to be
+    created in the same project as the consumer VPC network.
+    firewall_policy_rules overrides the global var.firewall_policy_rules for this specific VPC.
+  EOT
+}
+
+variable "firewall_policy_rules" {
+  type = list(object({
+    priority    = number
+    direction   = string
+    description = optional(string, "")
+    match = object({
+      src_ip_ranges  = optional(list(string), [])
+      dest_ip_ranges = optional(list(string), [])
+      layer4_configs = list(object({
+        ip_protocol = string
+        ports       = optional(list(string), [])
+      }))
+    })
+  }))
+  default = [
+    {
+      priority    = 1000
+      direction   = "EGRESS"
+      description = "Intercept all egress for PAN-OS inspection"
+      match = {
+        src_ip_ranges  = []
+        dest_ip_ranges = ["0.0.0.0/0"]
+        layer4_configs = [{ ip_protocol = "all" }]
+      }
+    }
+  ]
+  description = "Rules applied to each consumer VPC's global network firewall policy. The module automatically sets action=apply_security_profile_group."
+
+  validation {
+    condition     = alltrue([for r in var.firewall_policy_rules : contains(["INGRESS", "EGRESS"], r.direction)])
+    error_message = "Every firewall_policy_rules[*].direction must be either \"INGRESS\" or \"EGRESS\"."
+  }
+}
+
+variable "create_security_profile" {
+  type        = bool
+  default     = true
+  description = "Create the security_profile and security_profile_group. Set false to reuse an existing profile group."
+}
+
+variable "existing_security_profile_group_id" {
+  type        = string
+  default     = null
+  description = "Full ID of an existing security_profile_group. Required when create_security_profile = false."
+}

--- a/modules/nsi_intercept/versions.tf
+++ b/modules/nsi_intercept/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.3, < 2.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.15"
+    }
+  }
+}


### PR DESCRIPTION
Summary

- Add modules/nsi_intercept — new Terraform module implementing the full GCP Network Security Integration (NSI) resource chain on both the producer side (intercept deployment group, per-zone deployments, endpoint group, optional security profile and profile group) and consumer side (endpoint group associations with 30-minute timeouts, per-VPC network firewall policies with apply_security_profile_group rules). Supports per-VPC firewall rule overrides and bring-your-own security profile group. Requires google >= 6.15 where all NSI resources graduated to GA.
- Add modules/ncc_connectivity — new Terraform module creating a Network Connectivity Center hub (PRESET policy, MESH or STAR topology) with one linked VPC network spoke per consumer VPC. Supports bring-your-own hub via create_hub = false.
- Add examples/vmseries_nsi — end-to-end reference example deploying a zone-redundant active-active VM-Series fleet with NSI and NCC. Management and data interfaces are placed in separate VPCs so GCP internal LB health checks correctly target NIC1 (ethernet1/1, the GENEVE data interface) rather than the management NIC. One UDP/6081 ILB forwarding rule is provisioned per zone to satisfy NSI's zone-scoped intercept_deployment requirement. Bootstrap metadata automatically merges plugin-op-commands=geneve-inspect:enable required for PAN-OS 11.2+ GENEVE decapsulation. NCC and test Linux VMs are optional.
- Update modules/lb_internal — add protocol variable (default "TCP") to the backend service to allow UDP passthrough load balancers needed for GENEVE traffic. Fully backwards compatible with all existing examples.