### PR TITLE
fix(release_ci): Normalize output of gcloud asset search-all-resources

### DIFF
--- a/.github/actions/gcp_cleanup/cleanup.sh
+++ b/.github/actions/gcp_cleanup/cleanup.sh
@@ -106,6 +106,11 @@ RESOURCES=$(gcloud asset search-all-resources \
   --format="json(name,assetType,displayName,location)" \
   2>/dev/null || echo "[]")
 
+# gcloud may emit an empty result AND a non-zero exit (appending a second "[]"),
+# leaving $RESOURCES with multiple JSON documents. Slurp them into a single array
+# so downstream counts/arithmetic don't receive multi-line values.
+RESOURCES=$(echo "$RESOURCES" | jq -s 'add // []' 2>/dev/null || echo "[]")
+
 RESOURCE_COUNT=$(echo "$RESOURCES" | jq 'length')
 echo "Found ${RESOURCE_COUNT} resources to clean up."
 


### PR DESCRIPTION
## Description

Normalize the output of `gcloud asset search-all-resources` in `.github/actions/gcp_cleanup/cleanup.sh` into a single JSON array before counting resources.

## Motivation and Context

Release CI error : https://github.com/PaloAltoNetworks/terraform-google-swfw-modules/actions/runs/28141341399/job/83339314847

## How Has This Been Tested?

Will be tested via Release CI trigger .

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
