### PR TITLE
fix(release_ci): Increase release CI apply tiemout

### DIFF
--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -24,3 +24,4 @@ jobs:
       test_max_parallel: 5
       fail_fast: false
       terratest_action: Idempotence # keep in mind that this has to start with capital letter
+      apply_timeout: 60


### PR DESCRIPTION
## Description

- `cloud_ngfw` example is triggering timeout due to high apply/destroy - https://github.com/PaloAltoNetworks/terraform-google-swfw-modules/actions/runs/28559599352/job/84674520901
- Custom matrix element timeout was applied for `idempotence` chatops commnad but it was NOT applied to the release CI itself - thus failing the releases.

## Motivation and Context

- Issue within Release CI.

## How Has This Been Tested?

- N/A

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
